### PR TITLE
Make gateway public

### DIFF
--- a/crates/gateway/src/lib.rs
+++ b/crates/gateway/src/lib.rs
@@ -4,11 +4,11 @@ mod compiler_version;
 pub mod config;
 pub mod errors;
 pub mod gateway;
-mod rpc_objects;
-mod rpc_state_reader;
+pub mod rpc_objects;
+pub mod rpc_state_reader;
 #[cfg(test)]
 mod rpc_state_reader_test;
-mod state_reader;
+pub mod state_reader;
 #[cfg(test)]
 mod state_reader_test_utils;
 mod stateful_transaction_validator;


### PR DESCRIPTION
That way, we can use that structures in starknet-replay.

It is public in latest sequencer version, but not yet in our fork.