### PR TITLE
Add basic CI

### DIFF
--- a/.github/workflows/replay.yml
+++ b/.github/workflows/replay.yml
@@ -33,7 +33,9 @@ jobs:
       - name: Install LLVM
         run: sudo apt-get install llvm-19 llvm-19-dev llvm-19-runtime clang-19 clang-tools-19 lld-19 libpolly-19-dev libmlir-19-dev mlir-19-tools
       - name: Run cargo clippy
-        run: cargo clippy --all-targets --all-features
+        run: |
+          cd crates/blockifier
+          cargo clippy --all-targets --all-features --no-deps
 
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/replay.yml
+++ b/.github/workflows/replay.yml
@@ -1,0 +1,41 @@
+name: Replay
+
+on:
+  push:
+    branches: [main, replay]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    env:
+      MLIR_SYS_190_PREFIX: /usr/lib/llvm-19/
+      LLVM_SYS_191_PREFIX: /usr/lib/llvm-19/
+      TABLEGEN_190_PREFIX: /usr/lib/llvm-19/
+      CAIRO_NATIVE_RUNTIME_LIBRARY: libcairo_native_runtime.a
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.82.0
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Add LLVM Debian repository
+        uses: myci-actions/add-deb-repo@10
+        with:
+          repo: deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main
+          repo-name: llvm-repo
+          keys-asc: https://apt.llvm.org/llvm-snapshot.gpg.key
+      - name: Install LLVM
+        run: sudo apt-get install llvm-19 llvm-19-dev llvm-19-runtime clang-19 clang-tools-19 lld-19 libpolly-19-dev libmlir-19-dev mlir-19-tools
+      - name: Run cargo clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.82.0
+        with:
+          components: rustfmt
+      - name: Run cargo fmt
+        run: cargo fmt --all -- --check

--- a/.github/workflows/replay.yml
+++ b/.github/workflows/replay.yml
@@ -15,6 +15,9 @@ jobs:
       CAIRO_NATIVE_RUNTIME_LIBRARY: libcairo_native_runtime.a
     steps:
       - uses: actions/checkout@v4
+        with:
+          # required to clone native as a git submodule
+          submodules: recursive
       - uses: dtolnay/rust-toolchain@1.82.0
         with:
           components: clippy

--- a/.github/workflows/replay.yml
+++ b/.github/workflows/replay.yml
@@ -28,6 +28,8 @@ jobs:
           repo: deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main
           repo-name: llvm-repo
           keys-asc: https://apt.llvm.org/llvm-snapshot.gpg.key
+      - name: Install lld
+        run: sudo apt install lld
       - name: Install LLVM
         run: sudo apt-get install llvm-19 llvm-19-dev llvm-19-runtime clang-19 clang-tools-19 lld-19 libpolly-19-dev libmlir-19-dev mlir-19-tools
       - name: Run cargo clippy

--- a/.github/workflows/replay.yml
+++ b/.github/workflows/replay.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install LLVM
         run: sudo apt-get install llvm-19 llvm-19-dev llvm-19-runtime clang-19 clang-tools-19 lld-19 libpolly-19-dev libmlir-19-dev mlir-19-tools
       - name: Run cargo clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --all-targets --all-features
 
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/replay.yml
+++ b/.github/workflows/replay.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
 
 jobs:
-  check:
+  clippy:
     runs-on: ubuntu-latest
     env:
       MLIR_SYS_190_PREFIX: /usr/lib/llvm-19/

--- a/.github/workflows/replay.yml
+++ b/.github/workflows/replay.yml
@@ -34,8 +34,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@1.82.0
+      - uses: dtolnay/rust-toolchain@nightly
         with:
+          toolchain: nightly-2023-10-19
           components: rustfmt
       - name: Run cargo fmt
-        run: cargo fmt --all -- --check
+        run:  cargo +nightly-2023-10-19 fmt --all -- --check

--- a/crates/blockifier/src/execution/contract_class.rs
+++ b/crates/blockifier/src/execution/contract_class.rs
@@ -96,9 +96,7 @@ impl RunnableCompiledClass {
             Self::V0(class) => class.estimate_casm_hash_computation_resources(),
             Self::V1(class) => class.estimate_casm_hash_computation_resources(),
             #[cfg(feature = "cairo_native")]
-            Self::V1Native(_) => {
-                ExecutionResources::default()
-            }
+            Self::V1Native(_) => ExecutionResources::default(),
         }
     }
 

--- a/crates/blockifier/src/execution/execution_utils.rs
+++ b/crates/blockifier/src/execution/execution_utils.rs
@@ -148,12 +148,12 @@ pub fn execute_entry_point_call(
             //         context,
             //     )
             // } else {
-                native_entry_point_execution::execute_entry_point_call(
-                    call,
-                    compiled_class,
-                    state,
-                    context,
-                )
+            native_entry_point_execution::execute_entry_point_call(
+                call,
+                compiled_class,
+                state,
+                context,
+            )
             // }
         }
     }


### PR DESCRIPTION
Adds a new workflow for running clippy and cargo fmt. It doesn't remove the other ones to avoid conflicts later on.