### PR TITLE
Add profiling feature to disable stacker

### DIFF
--- a/crates/blockifier/Cargo.toml
+++ b/crates/blockifier/Cargo.toml
@@ -16,6 +16,7 @@ native_blockifier = []
 reexecution = ["transaction_serde"]
 testing = ["rand", "rstest", "starknet_api/testing"]
 transaction_serde = []
+profiling = []
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/blockifier/src/execution/native/entry_point_execution.rs
+++ b/crates/blockifier/src/execution/native/entry_point_execution.rs
@@ -54,7 +54,7 @@ pub fn execute_entry_point_call(
     // adjusting the stack size.
     // This also limits multi-threading, since each thread has its own stack.
     // TODO(Aviv/Yonatan): add these numbers to overridable VC.
-    let stack_size_red_zone = 160 * 1024 * 1024;
+    let stack_size_red_zone = if !cfg!(feature = "profiling") { 160 * 1024 * 1024 } else { 0 };
     let target_stack_size = stack_size_red_zone + 10 * 1024 * 1024;
     // Use `maybe_grow` and not `grow` for performance, since in happy flows, only the main call
     // should trigger the growth.


### PR DESCRIPTION
Using the stacker makes profiling more difficult, as samply has trouble determining the full callstack of the samples. This feature disables it.

It does it by setting the `red_zone` to zero. The stack is only grown when the remaining stack size is lower than the red zone, so setting it to zero disables the stack growth completely.