### PR TITLE
Add call counter to CallInfo

### DIFF
--- a/crates/blockifier/src/execution/call_info.rs
+++ b/crates/blockifier/src/execution/call_info.rs
@@ -208,6 +208,7 @@ pub struct CallInfo {
 
     // Additional information gathered during execution.
     pub time: std::time::Duration,
+    pub call_counter: usize,
     pub storage_read_values: Vec<Felt>,
     pub accessed_storage_keys: HashSet<StorageKey>,
     pub read_class_hash_values: Vec<ClassHash>,

--- a/crates/blockifier/src/execution/entry_point.rs
+++ b/crates/blockifier/src/execution/entry_point.rs
@@ -326,6 +326,9 @@ pub struct EntryPointExecutionContext {
 
     // Used to support charging for gas consumed in blockifier revert flow.
     pub sierra_gas_revert_tracker: SierraGasRevertTracker,
+
+    // Counts the nomber of calls executed
+    pub call_counter: usize,
 }
 
 impl EntryPointExecutionContext {
@@ -346,6 +349,7 @@ impl EntryPointExecutionContext {
             tracked_resource_stack: vec![],
             revert_infos: ExecutionRevertInfo(vec![]),
             sierra_gas_revert_tracker,
+            call_counter: 0,
         }
     }
 

--- a/crates/blockifier/src/execution/entry_point_execution.rs
+++ b/crates/blockifier/src/execution/entry_point_execution.rs
@@ -392,6 +392,7 @@ pub fn finalize_execution(
         read_class_hash_values: syscall_handler_base.read_class_hash_values,
         accessed_contract_addresses: syscall_handler_base.accessed_contract_addresses,
         time: std::time::Duration::default(),
+        call_counter: 0,
     })
 }
 

--- a/crates/blockifier/src/execution/execution_utils.rs
+++ b/crates/blockifier/src/execution/execution_utils.rs
@@ -115,6 +115,8 @@ pub fn execute_entry_point_call(
     state: &mut dyn State,
     context: &mut EntryPointExecutionContext,
 ) -> EntryPointExecutionResult<CallInfo> {
+    let current_call_counter = context.call_counter;
+    context.call_counter += 1;
     let pre_time = std::time::Instant::now();
     let mut result = match compiled_class {
         RunnableCompiledClass::V0(compiled_class) => {
@@ -152,6 +154,7 @@ pub fn execute_entry_point_call(
         }
     }?;
     result.time = pre_time.elapsed();
+    result.call_counter = current_call_counter;
     Ok(result)
 }
 

--- a/crates/blockifier/src/execution/native/entry_point_execution.rs
+++ b/crates/blockifier/src/execution/native/entry_point_execution.rs
@@ -103,5 +103,6 @@ fn create_callinfo(
         read_class_hash_values: syscall_handler.base.read_class_hash_values,
         tracked_resource: TrackedResource::SierraGas,
         time: std::time::Duration::default(),
+        call_counter: 0,
     })
 }


### PR DESCRIPTION
This PR adds call_counter to call info. This allows us to differentiate calls from each other, and easily find the faulty call.