### PR TITLE
add syscall builtin counts

### DIFF
--- a/crates/blockifier/src/execution/native/entry_point_execution.rs
+++ b/crates/blockifier/src/execution/native/entry_point_execution.rs
@@ -92,7 +92,7 @@ fn create_callinfo(
     let gas_consumed = syscall_handler.base.call.initial_gas - remaining_gas;
     let vm_resources = CallInfo::summarize_vm_resources(syscall_handler.base.inner_calls.iter());
 
-    // Retrive the builtin counts from the syscall handler
+    // Retrieve the builtin counts from the syscall handler
     let version_constants = syscall_handler.base.context.versioned_constants();
     let syscall_resources =
         version_constants.get_additional_os_syscall_resources(&syscall_handler.syscalls_usage);
@@ -135,10 +135,8 @@ fn builtin_stats_to_builtin_counter_map(
         builtin_stats.builtin_stats.pedersen
             + builtin_counts.get(&BuiltinName::pedersen).unwrap_or_default(),
     );
-    map
-        .insert(BuiltinName::ecdsa, builtin_counts.get(&BuiltinName::ecdsa).unwrap_or_default());
-    map
-        .insert(BuiltinName::keccak, builtin_counts.get(&BuiltinName::keccak).unwrap_or_default());
+    map.insert(BuiltinName::ecdsa, builtin_counts.get(&BuiltinName::ecdsa).unwrap_or_default());
+    map.insert(BuiltinName::keccak, builtin_counts.get(&BuiltinName::keccak).unwrap_or_default());
     map.insert(
         BuiltinName::bitwise,
         builtin_stats.builtin_stats.bitwise

--- a/crates/blockifier/src/execution/native/entry_point_execution.rs
+++ b/crates/blockifier/src/execution/native/entry_point_execution.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use cairo_native::execution_result::ContractExecutionResult;
+use cairo_native::execution_result::{BuiltinStats, ContractExecutionResult};
 use cairo_native::utils::BuiltinCosts;
 use cairo_vm::types::builtin_name::BuiltinName;
 use cairo_vm::vm::runners::cairo_runner::ExecutionResources;
@@ -16,6 +16,8 @@ use crate::execution::errors::{EntryPointExecutionError, PostExecutionError, Pre
 use crate::execution::native::contract_class::NativeCompiledClassV1;
 use crate::execution::native::syscall_handler::NativeSyscallHandler;
 use crate::state::state_api::State;
+
+type BuiltinCounterMap = HashMap<BuiltinName, &usize>;
 
 // todo(rodrigo): add an `entry point not found` test for Native
 pub fn execute_entry_point_call(
@@ -123,58 +125,56 @@ fn builtin_stats_to_builtin_counter_map(
 ) -> BuiltinCounterMap {
     let mut map = HashMap::new();
     let builtin_counts = syscall_counts.builtin_instance_counter;
-    builtin_stats.insert(
+    map.insert(
         BuiltinName::range_check,
-        call_result.builtin_stats.range_check
+        builtin_stats.builtin_stats.range_check
             + builtin_counts.get(&BuiltinName::range_check).unwrap_or_default(),
     );
-    builtin_stats.insert(
+    map.insert(
         BuiltinName::pedersen,
-        call_result.builtin_stats.pedersen
+        builtin_stats.builtin_stats.pedersen
             + builtin_counts.get(&BuiltinName::pedersen).unwrap_or_default(),
     );
-    builtin_stats
+    map
         .insert(BuiltinName::ecdsa, builtin_counts.get(&BuiltinName::ecdsa).unwrap_or_default());
-    builtin_stats
+    map
         .insert(BuiltinName::keccak, builtin_counts.get(&BuiltinName::keccak).unwrap_or_default());
-    builtin_stats.insert(
+    map.insert(
         BuiltinName::bitwise,
-        call_result.builtin_stats.bitwise
+        builtin_stats.builtin_stats.bitwise
             + builtin_counts.get(&BuiltinName::bitwise).unwrap_or_default(),
     );
-    builtin_stats.insert(
+    map.insert(
         BuiltinName::ec_op,
-        call_result.builtin_stats.ec_op
+        builtin_stats.builtin_stats.ec_op
             + builtin_counts.get(&BuiltinName::ec_op).unwrap_or_default(),
     );
-    builtin_stats.insert(
+    map.insert(
         BuiltinName::poseidon,
-        call_result.builtin_stats.poseidon
+        builtin_stats.builtin_stats.poseidon
             + builtin_counts.get(&BuiltinName::poseidon).unwrap_or_default(),
     );
-    builtin_stats.insert(
+    map.insert(
         BuiltinName::segment_arena,
-        call_result.builtin_stats.segment_arena
+        builtin_stats.builtin_stats.segment_arena
             + builtin_counts.get(&BuiltinName::segment_arena).unwrap_or_default(),
     );
-    builtin_stats.insert(
+    map.insert(
         BuiltinName::range_check96,
-        call_result.builtin_stats.range_check96
+        builtin_stats.builtin_stats.range_check96
             + builtin_counts.get(&BuiltinName::range_check96).unwrap_or_default(),
     );
-    builtin_stats.insert(
+    map.insert(
         BuiltinName::add_mod,
-        call_result.builtin_stats.add_mod
+        builtin_stats.builtin_stats.add_mod
             + builtin_counts.get(&BuiltinName::add_mod).unwrap_or_default(),
     );
-    builtin_stats.insert(
+    map.insert(
         BuiltinName::mul_mod,
-        call_result.builtin_stats.mul_mod
+        builtin_stats.builtin_stats.mul_mod
             + builtin_counts.get(&BuiltinName::mul_mod).unwrap_or_default(),
     );
-    builtin_stats.retain(|_, &mut v| v != 0);
-
-    dbg!(builtin_counts);
+    map.retain(|_, &mut v| v != 0);
 
     map
 }

--- a/crates/blockifier/src/execution/native/entry_point_execution.rs
+++ b/crates/blockifier/src/execution/native/entry_point_execution.rs
@@ -127,50 +127,54 @@ fn builtin_stats_to_builtin_counter_map(
     let builtin_counts = syscall_counts.builtin_instance_counter;
     map.insert(
         BuiltinName::range_check,
-        builtin_stats.builtin_stats.range_check
-            + builtin_counts.get(&BuiltinName::range_check).unwrap_or_default(),
+        builtin_stats.range_check
+            + builtin_counts.get(&BuiltinName::range_check).copied().unwrap_or_default(),
     );
     map.insert(
         BuiltinName::pedersen,
-        builtin_stats.builtin_stats.pedersen
-            + builtin_counts.get(&BuiltinName::pedersen).unwrap_or_default(),
+        builtin_stats.pedersen + builtin_counts.get(&BuiltinName::pedersen).unwrap_or_default(),
     );
-    map.insert(BuiltinName::ecdsa, builtin_counts.get(&BuiltinName::ecdsa).unwrap_or_default());
-    map.insert(BuiltinName::keccak, builtin_counts.get(&BuiltinName::keccak).unwrap_or_default());
+    map.insert(
+        BuiltinName::ecdsa,
+        builtin_counts.get(&BuiltinName::ecdsa).copied().unwrap_or_default(),
+    );
+    map.insert(
+        BuiltinName::keccak,
+        builtin_counts.get(&BuiltinName::keccak).copied().unwrap_or_default(),
+    );
     map.insert(
         BuiltinName::bitwise,
-        builtin_stats.builtin_stats.bitwise
-            + builtin_counts.get(&BuiltinName::bitwise).unwrap_or_default(),
+        builtin_stats.bitwise
+            + builtin_counts.get(&BuiltinName::bitwise).copied().unwrap_or_default(),
     );
     map.insert(
         BuiltinName::ec_op,
-        builtin_stats.builtin_stats.ec_op
-            + builtin_counts.get(&BuiltinName::ec_op).unwrap_or_default(),
+        builtin_stats.ec_op + builtin_counts.get(&BuiltinName::ec_op).copied().unwrap_or_default(),
     );
     map.insert(
         BuiltinName::poseidon,
-        builtin_stats.builtin_stats.poseidon
-            + builtin_counts.get(&BuiltinName::poseidon).unwrap_or_default(),
+        builtin_stats.poseidon
+            + builtin_counts.get(&BuiltinName::poseidon).copied().unwrap_or_default(),
     );
     map.insert(
         BuiltinName::segment_arena,
-        builtin_stats.builtin_stats.segment_arena
-            + builtin_counts.get(&BuiltinName::segment_arena).unwrap_or_default(),
+        builtin_stats.segment_arena
+            + builtin_counts.get(&BuiltinName::segment_arena).copied().unwrap_or_default(),
     );
     map.insert(
         BuiltinName::range_check96,
-        builtin_stats.builtin_stats.range_check96
-            + builtin_counts.get(&BuiltinName::range_check96).unwrap_or_default(),
+        builtin_stats.range_check96
+            + builtin_counts.get(&BuiltinName::range_check96).copied().unwrap_or_default(),
     );
     map.insert(
         BuiltinName::add_mod,
-        builtin_stats.builtin_stats.add_mod
-            + builtin_counts.get(&BuiltinName::add_mod).unwrap_or_default(),
+        builtin_stats.add_mod
+            + builtin_counts.get(&BuiltinName::add_mod).copied().unwrap_or_default(),
     );
     map.insert(
         BuiltinName::mul_mod,
-        builtin_stats.builtin_stats.mul_mod
-            + builtin_counts.get(&BuiltinName::mul_mod).unwrap_or_default(),
+        builtin_stats.mul_mod
+            + builtin_counts.get(&BuiltinName::mul_mod).copied().unwrap_or_default(),
     );
     map.retain(|_, &mut v| v != 0);
 

--- a/crates/blockifier/src/execution/native/entry_point_execution.rs
+++ b/crates/blockifier/src/execution/native/entry_point_execution.rs
@@ -92,7 +92,8 @@ fn create_callinfo(
 
     // Retrive the builtin counts from the syscall handler
     let version_constants = syscall_handler.base.context.versioned_constants();
-    let syscall_resources = version_constants.get_additional_os_syscall_resources(&syscall_handler.syscalls_usage);
+    let syscall_resources =
+        version_constants.get_additional_os_syscall_resources(&syscall_handler.syscalls_usage);
 
     Ok(CallInfo {
         call: syscall_handler.base.call.into(),
@@ -116,22 +117,63 @@ fn create_callinfo(
     })
 }
 
-fn builtin_stats_to_builtin_counter_map(builtin_stats: BuiltinStats, syscall_counts: ExecutionResources) -> BuiltinCounterMap {
+fn builtin_stats_to_builtin_counter_map(
+    builtin_stats: BuiltinStats,
+    syscall_counts: ExecutionResources,
+) -> BuiltinCounterMap {
     let mut map = HashMap::new();
     let builtin_counts = syscall_counts.builtin_instance_counter;
-    builtin_stats.insert(BuiltinName::range_check, call_result.builtin_stats.range_check + builtin_counts.get(&BuiltinName::range_check).unwrap_or_default());
-    builtin_stats.insert(BuiltinName::pedersen, call_result.builtin_stats.pedersen + builtin_counts.get(&BuiltinName::pedersen).unwrap_or_default());
-    builtin_stats.insert(BuiltinName::ecdsa,  builtin_counts.get(&BuiltinName::ecdsa).unwrap_or_default());
-    builtin_stats.insert(BuiltinName::keccak,  builtin_counts.get(&BuiltinName::keccak).unwrap_or_default());
-    builtin_stats.insert(BuiltinName::bitwise, call_result.builtin_stats.bitwise + builtin_counts.get(&BuiltinName::bitwise).unwrap_or_default());
-    builtin_stats.insert(BuiltinName::ec_op, call_result.builtin_stats.ec_op + builtin_counts.get(&BuiltinName::ec_op).unwrap_or_default());
-    builtin_stats.insert(BuiltinName::poseidon, call_result.builtin_stats.poseidon + builtin_counts.get(&BuiltinName::poseidon).unwrap_or_default());
-    builtin_stats.insert(BuiltinName::segment_arena, call_result.builtin_stats.segment_arena + builtin_counts.get(&BuiltinName::segment_arena).unwrap_or_default());
-    builtin_stats.insert(BuiltinName::range_check96, call_result.builtin_stats.range_check96 + builtin_counts.get(&BuiltinName::range_check96).unwrap_or_default());
-    builtin_stats.insert(BuiltinName::add_mod, call_result.builtin_stats.add_mod + builtin_counts.get(&BuiltinName::add_mod).unwrap_or_default());
-    builtin_stats.insert(BuiltinName::mul_mod, call_result.builtin_stats.mul_mod + builtin_counts.get(&BuiltinName::mul_mod).unwrap_or_default());
+    builtin_stats.insert(
+        BuiltinName::range_check,
+        call_result.builtin_stats.range_check
+            + builtin_counts.get(&BuiltinName::range_check).unwrap_or_default(),
+    );
+    builtin_stats.insert(
+        BuiltinName::pedersen,
+        call_result.builtin_stats.pedersen
+            + builtin_counts.get(&BuiltinName::pedersen).unwrap_or_default(),
+    );
+    builtin_stats
+        .insert(BuiltinName::ecdsa, builtin_counts.get(&BuiltinName::ecdsa).unwrap_or_default());
+    builtin_stats
+        .insert(BuiltinName::keccak, builtin_counts.get(&BuiltinName::keccak).unwrap_or_default());
+    builtin_stats.insert(
+        BuiltinName::bitwise,
+        call_result.builtin_stats.bitwise
+            + builtin_counts.get(&BuiltinName::bitwise).unwrap_or_default(),
+    );
+    builtin_stats.insert(
+        BuiltinName::ec_op,
+        call_result.builtin_stats.ec_op
+            + builtin_counts.get(&BuiltinName::ec_op).unwrap_or_default(),
+    );
+    builtin_stats.insert(
+        BuiltinName::poseidon,
+        call_result.builtin_stats.poseidon
+            + builtin_counts.get(&BuiltinName::poseidon).unwrap_or_default(),
+    );
+    builtin_stats.insert(
+        BuiltinName::segment_arena,
+        call_result.builtin_stats.segment_arena
+            + builtin_counts.get(&BuiltinName::segment_arena).unwrap_or_default(),
+    );
+    builtin_stats.insert(
+        BuiltinName::range_check96,
+        call_result.builtin_stats.range_check96
+            + builtin_counts.get(&BuiltinName::range_check96).unwrap_or_default(),
+    );
+    builtin_stats.insert(
+        BuiltinName::add_mod,
+        call_result.builtin_stats.add_mod
+            + builtin_counts.get(&BuiltinName::add_mod).unwrap_or_default(),
+    );
+    builtin_stats.insert(
+        BuiltinName::mul_mod,
+        call_result.builtin_stats.mul_mod
+            + builtin_counts.get(&BuiltinName::mul_mod).unwrap_or_default(),
+    );
     builtin_stats.retain(|_, &mut v| v != 0);
-    
+
     dbg!(builtin_counts);
 
     map

--- a/crates/blockifier/src/execution/native/syscall_handler.rs
+++ b/crates/blockifier/src/execution/native/syscall_handler.rs
@@ -759,7 +759,6 @@ impl StarknetSyscallHandler for &mut NativeSyscallHandler<'_> {
         signature: &[Felt],
         remaining_gas: &mut u64,
     ) -> SyscallResult<Vec<Felt>> {
-        self.increment_syscall_count_by(&SyscallSelector::MetaTxV0, calldata.len());
         todo!(
             "implement meta_tx_v0 {:?}",
             (address, entry_point_selector, calldata, signature, remaining_gas)

--- a/crates/blockifier/src/execution/native/syscall_handler.rs
+++ b/crates/blockifier/src/execution/native/syscall_handler.rs
@@ -354,6 +354,7 @@ impl StarknetSyscallHandler for &mut NativeSyscallHandler<'_> {
             remaining_gas,
             self.gas_costs().syscalls.replace_class.base_syscall_cost(),
         )?;
+        self.increment_syscall_count_by(&SyscallSelector::ReplaceClass, 1);
 
         self.base
             .replace_class(ClassHash(class_hash))

--- a/crates/blockifier/src/execution/native/syscall_handler.rs
+++ b/crates/blockifier/src/execution/native/syscall_handler.rs
@@ -36,7 +36,11 @@ use crate::execution::entry_point::{
 use crate::execution::errors::EntryPointExecutionError;
 use crate::execution::native::utils::{calculate_resource_bounds, default_tx_v2_info};
 use crate::execution::secp;
-use crate::execution::syscalls::hint_processor::{SyscallExecutionError, SyscallUsageMap, OUT_OF_GAS_ERROR};
+use crate::execution::syscalls::hint_processor::{
+    SyscallExecutionError,
+    SyscallUsageMap,
+    OUT_OF_GAS_ERROR,
+};
 use crate::execution::syscalls::syscall_base::SyscallHandlerBase;
 use crate::execution::syscalls::SyscallSelector;
 use crate::state::state_api::State;
@@ -327,10 +331,7 @@ impl StarknetSyscallHandler for &mut NativeSyscallHandler<'_> {
         let total_gas_cost =
             self.gas_costs().syscalls.deploy.get_syscall_cost(u64_from_usize(calldata.len()));
         self.pre_execute_syscall(remaining_gas, total_gas_cost)?;
-        self.increment_syscall_count_by(
-            &SyscallSelector::Deploy,
-            calldata.len(),
-        );
+        self.increment_syscall_count_by(&SyscallSelector::Deploy, calldata.len());
 
         let (deployed_contract_address, call_info) = self
             .base
@@ -758,10 +759,7 @@ impl StarknetSyscallHandler for &mut NativeSyscallHandler<'_> {
         signature: &[Felt],
         remaining_gas: &mut u64,
     ) -> SyscallResult<Vec<Felt>> {
-        self.increment_syscall_count_by(
-            &SyscallSelector::MetaTxV0,
-            calldata.len(),
-        );
+        self.increment_syscall_count_by(&SyscallSelector::MetaTxV0, calldata.len());
         todo!(
             "implement meta_tx_v0 {:?}",
             (address, entry_point_selector, calldata, signature, remaining_gas)

--- a/crates/blockifier/src/execution/native/syscall_handler.rs
+++ b/crates/blockifier/src/execution/native/syscall_handler.rs
@@ -560,13 +560,16 @@ impl StarknetSyscallHandler for &mut NativeSyscallHandler<'_> {
             remaining_gas,
             self.gas_costs().syscalls.keccak.base_syscall_cost(),
         )?;
-        self.increment_syscall_count_by(&SyscallSelector::Keccak, n_rounds);
 
         match self.base.keccak(input, remaining_gas) {
-            Ok((state, _n_rounds)) => Ok(U256 {
-                hi: u128::from(state[2]) | (u128::from(state[3]) << 64),
-                lo: u128::from(state[0]) | (u128::from(state[1]) << 64),
-            }),
+            Ok((state, n_rounds)) => {
+                self.increment_syscall_count_by(&SyscallSelector::Keccak, n_rounds);
+
+                Ok(U256 {
+                    hi: u128::from(state[2]) | (u128::from(state[3]) << 64),
+                    lo: u128::from(state[0]) | (u128::from(state[1]) << 64),
+                })
+            }
             Err(err) => Err(self.handle_error(remaining_gas, err)),
         }
     }


### PR DESCRIPTION
We were missing the builtin counts produced when calling syscalls. This PRs adds them for every syscall independently.