### PR TITLE
[DNM] Fix OS bug

### DIFF
--- a/crates/blockifier/src/execution/deprecated_syscalls/hint_processor.rs
+++ b/crates/blockifier/src/execution/deprecated_syscalls/hint_processor.rs
@@ -1,5 +1,5 @@
 use std::any::Any;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 use cairo_vm::hint_processor::builtin_hint_processor::builtin_hint_processor_definition::{
     BuiltinHintProcessor,
@@ -440,7 +440,6 @@ impl HintProcessorLogic for DeprecatedSyscallHintProcessor<'_> {
         vm: &mut VirtualMachine,
         exec_scopes: &mut ExecutionScopes,
         hint_data: &Box<dyn Any>,
-        constants: &HashMap<String, Felt>,
     ) -> HintExecutionResult {
         let hint = hint_data.downcast_ref::<HintProcessorData>().ok_or(HintError::WrongHintData)?;
         if hint_code::SYSCALL_HINTS.contains(hint.code.as_str()) {
@@ -452,7 +451,7 @@ impl HintProcessorLogic for DeprecatedSyscallHintProcessor<'_> {
             )?);
         }
 
-        self.builtin_hint_processor.execute_hint(vm, exec_scopes, hint_data, constants)
+        self.builtin_hint_processor.execute_hint(vm, exec_scopes, hint_data)
     }
 }
 

--- a/crates/blockifier/src/execution/syscalls/hint_processor.rs
+++ b/crates/blockifier/src/execution/syscalls/hint_processor.rs
@@ -1,5 +1,6 @@
 use std::any::Any;
 use std::collections::HashMap;
+use std::rc::Rc;
 
 use cairo_lang_casm::hints::Hint;
 use cairo_lang_runner::casm_run::execute_core_hint_base;
@@ -759,7 +760,6 @@ impl HintProcessorLogic for SyscallHintProcessor<'_> {
         vm: &mut VirtualMachine,
         exec_scopes: &mut ExecutionScopes,
         hint_data: &Box<dyn Any>,
-        _constants: &HashMap<String, Felt>,
     ) -> HintExecutionResult {
         let hint = hint_data.downcast_ref::<Hint>().ok_or(HintError::WrongHintData)?;
         // Segment arena finalization is relevant only for proof so there is no need to allocate
@@ -783,6 +783,7 @@ impl HintProcessorLogic for SyscallHintProcessor<'_> {
         _ap_tracking_data: &ApTracking,
         _reference_ids: &HashMap<String, usize>,
         _references: &[HintReference],
+        _constants: Rc<HashMap<String, Felt>>,
     ) -> Result<Box<dyn Any>, VirtualMachineError> {
         Ok(Box::new(self.hints[hint_code].clone()))
     }

--- a/crates/blockifier_test_utils/resources/feature_contracts/cairo0/compiled/test_contract_compiled.json
+++ b/crates/blockifier_test_utils/resources/feature_contracts/cairo0/compiled/test_contract_compiled.json
@@ -33,6 +33,17 @@
             "type": "constructor"
         },
         {
+            "inputs": [
+                {
+                    "name": "value",
+                    "type": "felt"
+                }
+            ],
+            "name": "split_felt_wrapper",
+            "outputs": [],
+            "type": "function"
+        },
+        {
             "inputs": [],
             "name": "without_arg",
             "outputs": [],
@@ -721,165 +732,169 @@
     "entry_points_by_type": {
         "CONSTRUCTOR": [
             {
-                "offset": 510,
+                "offset": 548,
                 "selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194"
             }
         ],
         "EXTERNAL": [
             {
-                "offset": 1451,
+                "offset": 1513,
                 "selector": "0x1143aa89c8e3ebf8ed14df2a3606c1cd2dd513fac8040b0f8ab441f5c52fe4"
             },
             {
-                "offset": 1493,
+                "offset": 1555,
                 "selector": "0x600c98a299d72ef1e09a2e1503206fbc76081233172c65f7e2438ef0069d8d"
             },
             {
-                "offset": 1367,
+                "offset": 1429,
                 "selector": "0x62c83572d28cb834a3de3c1e94977a4191469a4a8c26d1d7bc55305e640ed5"
             },
             {
-                "offset": 2007,
+                "offset": 2069,
                 "selector": "0x679c22735055a10db4f275395763a3752a1e3a3043c192299ab6b574fba8d6"
             },
             {
-                "offset": 1931,
+                "offset": 1993,
                 "selector": "0x7772be8b80a8a33dc6c1f9a6ab820c02e537c73e859de67f288c70f92571bb"
             },
             {
-                "offset": 625,
+                "offset": 573,
+                "selector": "0x99b00a4c2bd86339297215b2c44b18ff875c6834d9ece0ccf92ed80b4d1793"
+            },
+            {
+                "offset": 687,
                 "selector": "0xad451bd0dba3d8d97104e1bfc474f88605ccc7acbe1c846839a120fdf30d95"
             },
             {
-                "offset": 969,
+                "offset": 1031,
                 "selector": "0xb0ee07785692bd1fcda9089aadef94621bfa2ac0e849504ca54f05a3689f8e"
             },
             {
-                "offset": 1757,
+                "offset": 1819,
                 "selector": "0xd47144c49bce05b6de6bce9d5ff0cc8da9420f8945453e20ef779cbea13ad4"
             },
             {
-                "offset": 1110,
+                "offset": 1172,
                 "selector": "0xe7510edcf6e9f1b70f7bd1f488767b50f0363422f3c563160ab77adf62467b"
             },
             {
-                "offset": 547,
+                "offset": 609,
                 "selector": "0xe7def693d16806ca2a2f398d8de5951344663ba77f340ed7a958da731872fc"
             },
             {
-                "offset": 797,
+                "offset": 859,
                 "selector": "0x120c24672855cfe872cb35256ea85172417f2aada7a22c15908906dc5f3c69d"
             },
             {
-                "offset": 1724,
+                "offset": 1786,
                 "selector": "0x127a04cfe41aceb22fc022bce0c5c70f2d860a7c7c054681bd821cdc18e6dbc"
             },
             {
-                "offset": 2084,
+                "offset": 2146,
                 "selector": "0x12ead94ae9d3f9d2bdb6b847cf255f1f398193a1f88884a0ae8e18f24a037b6"
             },
             {
-                "offset": 650,
+                "offset": 712,
                 "selector": "0x137a07fa9c479e27114b8ae1fbf252f2065cf91a0d8615272e060a7ccf37309"
             },
             {
-                "offset": 2137,
+                "offset": 2199,
                 "selector": "0x14dae1999ae9ab799bc72def6dc6e90890cf8ac0d64525021b7e71d05cb13e8"
             },
             {
-                "offset": 1615,
+                "offset": 1677,
                 "selector": "0x167ac610845cc0ab1501b38169a7e50f1bf60602d3c2a961b30987454f97812"
             },
             {
-                "offset": 1146,
+                "offset": 1208,
                 "selector": "0x169f135eddda5ab51886052d777a57f2ea9c162d713691b5e04a6d4ed71d47f"
             },
             {
-                "offset": 2048,
+                "offset": 2110,
                 "selector": "0x1ae1a515cf2d214b29bdf63a79ee2d490efd4dd1acc99d383a8e549c3cecb5d"
             },
             {
-                "offset": 1268,
+                "offset": 1330,
                 "selector": "0x1b1a0649752af1b28b3dc29a1556eee781e4a4c3a1f7f53f90fa834de098c4d"
             },
             {
-                "offset": 754,
+                "offset": 816,
                 "selector": "0x1b47f727a0668d8593c5bb115d5b53a470f29833fd4d598e748f68e65f4f003"
             },
             {
-                "offset": 1694,
+                "offset": 1756,
                 "selector": "0x1de4779362d5ca708d55fe1d4d499501b7f692730d2e01656e9180708985e07"
             },
             {
-                "offset": 931,
+                "offset": 993,
                 "selector": "0x27c3334165536f239cfd400ed956eabff55fc60de4fb56728b6a4f6b87db01c"
             },
             {
-                "offset": 1036,
+                "offset": 1098,
                 "selector": "0x298e03955860424b6a946506da72353a645f653dc1879f6b55fd756f3d20a59"
             },
             {
-                "offset": 1560,
+                "offset": 1622,
                 "selector": "0x309687d54611a7db521175c78ba48b082df1372350d2529981a8c0dd09a6529"
             },
             {
-                "offset": 1963,
+                "offset": 2025,
                 "selector": "0x30f842021fbf02caf80d09a113997c1e00a32870eee0c6136bed27acb348bea"
             },
             {
-                "offset": 1883,
+                "offset": 1945,
                 "selector": "0x317eb442b72a9fae758d4fb26830ed0d9f31c8e7da4dbff4e8c59ea6a158e7f"
             },
             {
-                "offset": 1400,
+                "offset": 1462,
                 "selector": "0x32564d7e0fe091d49b4c20f4632191e4ed6986bf993849879abfef9465def25"
             },
             {
-                "offset": 724,
+                "offset": 786,
                 "selector": "0x3307b3297ab2ab7a46a9b7d139a52dddf9c343e9a0a3ac69c5b4048d80e3aaf"
             },
             {
-                "offset": 1639,
+                "offset": 1701,
                 "selector": "0x33ce93a3eececa5c9fc70da05f4aff3b00e1820b79587924d514bc76788991a"
             },
             {
-                "offset": 819,
+                "offset": 881,
                 "selector": "0x3604cea1cdb094a73a31144f14a3e5861613c008e1e879939ebc4827d10cd50"
             },
             {
-                "offset": 1198,
+                "offset": 1260,
                 "selector": "0x36fa6de2810d05c3e1a0ebe23f60b9c2f4629bbead09e5a9704e1c5632630d5"
             },
             {
-                "offset": 1234,
+                "offset": 1296,
                 "selector": "0x38215592552d97419658d30db8f189b242ec2056641de3dff8a7217745ec205"
             },
             {
-                "offset": 530,
+                "offset": 592,
                 "selector": "0x382a967a31be13f23e23a5345f7a89b0362cc157d6fbe7564e6396a83cf4b4f"
             },
             {
-                "offset": 575,
+                "offset": 637,
                 "selector": "0x39a1491f76903a16feed0a6433bec78de4c73194944e1118e226820ad479701"
             },
             {
-                "offset": 892,
+                "offset": 954,
                 "selector": "0x3a6a8bae4c51d5959683ae246347ffdd96aa5b2bfa68cc8c3a6a7c2ed0be331"
             },
             {
-                "offset": 686,
+                "offset": 748,
                 "selector": "0x3b097c62d3e4b85742aadd0dfb823f96134b886ec13bda57b68faf86f294d97"
             },
             {
-                "offset": 1086,
+                "offset": 1148,
                 "selector": "0x3bf01fb7497d041938cb7b2954d8c4590006d26b3acd0f5aec1af45dc4f94b2"
             },
             {
-                "offset": 1591,
+                "offset": 1653,
                 "selector": "0x3dc5da2d6d1275aeed57f43461d31967b0fed58bfe739b4ffad4091e89c4b03"
             },
             {
-                "offset": 1426,
+                "offset": 1488,
                 "selector": "0x3eb640b15f75fcc06d43182cdb94ed38c8e71755d5fb57c16dd673b466db1d4"
             }
         ],
@@ -893,16 +908,16 @@
                     "__main__",
                     "__main__.test_call_contract_fail_with_attr_error_msg"
                 ],
-                "end_pc": 1084,
+                "end_pc": 1146,
                 "flow_tracking_data": {
                     "ap_tracking": {
-                        "group": 88,
+                        "group": 93,
                         "offset": 0
                     },
                     "reference_ids": {}
                 },
                 "name": "error_message",
-                "start_pc": 1074,
+                "start_pc": 1136,
                 "value": "Be aware of failure ahead..."
             },
             {
@@ -911,16 +926,16 @@
                     "__main__",
                     "__main__.fail"
                 ],
-                "end_pc": 1399,
+                "end_pc": 1461,
                 "flow_tracking_data": {
                     "ap_tracking": {
-                        "group": 110,
+                        "group": 115,
                         "offset": 0
                     },
                     "reference_ids": {}
                 },
                 "name": "error_message",
-                "start_pc": 1395,
+                "start_pc": 1457,
                 "value": "You shall not pass!"
             }
         ],
@@ -1093,6 +1108,15 @@
             "0x482680017ffc8000",
             "0x2",
             "0x208b7fff7fff7ffe",
+            "0x400380007ffc7ffd",
+            "0x482680017ffc8000",
+            "0x1",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ffb7fff8000",
+            "0x48297ffc80007ffd",
+            "0x1104800180018000",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffffb",
+            "0x208b7fff7fff7ffe",
             "0x480680017fff8000",
             "0x3ffffffffffffffffffffffffffffff",
             "0x480280017ffc8000",
@@ -1106,6 +1130,35 @@
             "0x482680017ffc8000",
             "0x3",
             "0x208b7fff7fff7ffe",
+            "0x480280017ffc8000",
+            "0x484480017fff8000",
+            "0x100000000000000000000000000000000",
+            "0x480280007ffc8000",
+            "0x40317fff7ffe7ffd",
+            "0x480280017ffc8000",
+            "0x482480017fff8000",
+            "0x800000000000010fffffffffffffffff7ffffffffffffef0000000000000001",
+            "0x20680017fff7fff",
+            "0xb",
+            "0x482680017ffc8000",
+            "0x2",
+            "0x480280007ffc8000",
+            "0x480680017fff8000",
+            "0x0",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe0",
+            "0x10780017fff7fff",
+            "0x9",
+            "0x482680017ffc8000",
+            "0x2",
+            "0x480280017ffc8000",
+            "0x480680017fff8000",
+            "0x800000000000010ffffffffffffffff",
+            "0x1104800180018000",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd7",
+            "0x480280017ffc8000",
+            "0x480280007ffc8000",
+            "0x208b7fff7fff7ffe",
             "0x40780017fff7fff",
             "0x1",
             "0x20680017fff7fff",
@@ -1114,13 +1167,13 @@
             "0x482680017ffd8000",
             "0x11000000000000000000000000000000000000000000000101",
             "0x1104800180018000",
-            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffed",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd0",
             "0x480680017fff8000",
             "0x800000000000011000000000000000000000000000000000000000000000000",
             "0x48127ffe7fff8000",
             "0x48287ffd80007ffe",
             "0x1104800180018000",
-            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffe7",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffca",
             "0x482680017ffd8000",
             "0x11000000000000000000000000000000000000000000000101",
             "0x208b7fff7fff7ffe",
@@ -1135,7 +1188,7 @@
             "0x480a7ffc7fff8000",
             "0x48287ffd80007ffe",
             "0x1104800180018000",
-            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd8",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffbb",
             "0x10780017fff7fff",
             "0x8",
             "0x40780017fff7fff",
@@ -1143,7 +1196,7 @@
             "0x480a7ffc7fff8000",
             "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffd0",
+            "0x800000000000010ffffffffffffffffffffffffffffffffffffffffffffffb3",
             "0x480a7ffd7fff8000",
             "0x208b7fff7fff7ffe",
             "0x400380007ffb7ffc",
@@ -1272,7 +1325,7 @@
             "0x40780017fff7fff",
             "0x2",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffec6",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffea0",
             "0x400780017fff8000",
             "0x0",
             "0x400780017fff8001",
@@ -1288,7 +1341,7 @@
             "0x1104800180018000",
             "0x2b",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffeb6",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffe90",
             "0x40137ffd7fff8000",
             "0x480280017ffb8000",
             "0x40297ffd7fff8001",
@@ -1301,9 +1354,9 @@
             "0x480280007ffc8000",
             "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffe94",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffe6e",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffea7",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffe81",
             "0x40137ffd7fff8000",
             "0x480280017ffc8000",
             "0x402580017fff8001",
@@ -1326,7 +1379,7 @@
             "0x480280007ffd8000",
             "0x480280017ffd8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffe7b",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffe55",
             "0x208b7fff7fff7ffe",
             "0x20780017fff7ffc",
             "0x5",
@@ -1400,7 +1453,7 @@
             "0x391a88f3badec8650b4d8356e18655269ee975e58e0060aa076396ce0b1dccb",
             "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffe31",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffe0b",
             "0x480a7ffc7fff8000",
             "0x48127ffe7fff8000",
             "0x1104800180018000",
@@ -1417,7 +1470,7 @@
             "0x480a7ffa7fff8000",
             "0x48127ffe7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffe96",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffe70",
             "0x48127ffe7fff8000",
             "0x48127ff57fff8000",
             "0x48127ff57fff8000",
@@ -1432,7 +1485,7 @@
             "0x48127ffe7fff8000",
             "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffe8f",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffe69",
             "0x48127ff67fff8000",
             "0x48127ff67fff8000",
             "0x208b7fff7fff7ffe",
@@ -1440,7 +1493,7 @@
             "0x480a7ffc7fff8000",
             "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffe87",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffe61",
             "0x208b7fff7fff7ffe",
             "0x482680017ffd8000",
             "0x2",
@@ -1455,6 +1508,30 @@
             "0x48127ffe7fff8000",
             "0x480280017ffb8000",
             "0x480280027ffb8000",
+            "0x480280037ffb8000",
+            "0x480280047ffb8000",
+            "0x480680017fff8000",
+            "0x0",
+            "0x48127ff97fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x480a7ffc7fff8000",
+            "0x480a7ffd7fff8000",
+            "0x1104800180018000",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffe7f",
+            "0x48127ffd7fff8000",
+            "0x208b7fff7fff7ffe",
+            "0x482680017ffd8000",
+            "0x1",
+            "0x402a7ffd7ffc7fff",
+            "0x480280027ffb8000",
+            "0x480280007ffd8000",
+            "0x1104800180018000",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffff6",
+            "0x40780017fff7fff",
+            "0x1",
+            "0x480280007ffb8000",
+            "0x480280017ffb8000",
+            "0x48127ffc7fff8000",
             "0x480280037ffb8000",
             "0x480280047ffb8000",
             "0x480680017fff8000",
@@ -1531,7 +1608,7 @@
             "0x480680017fff8000",
             "0x6",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffdc4",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffd86",
             "0x482480017fff8000",
             "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffffe",
             "0x480a7ffd7fff8000",
@@ -1543,10 +1620,10 @@
             "0x3",
             "0x48127ffb7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffdd5",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffd97",
             "0x48127ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffdff",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffdc1",
             "0x48127ffe7fff8000",
             "0x208b7fff7fff7ffe",
             "0x400380007ffb7ffc",
@@ -1604,10 +1681,10 @@
             "0x480a7ffc7fff8000",
             "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffde3",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffda5",
             "0x480a7ffc7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffdd8",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffd9a",
             "0x208b7fff7fff7ffe",
             "0x40780017fff7fff",
             "0x1",
@@ -1649,7 +1726,7 @@
             "0x480a7ffc7fff8000",
             "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffdb6",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffd78",
             "0x482680017ffc8000",
             "0x800000000000011000000000000000000000000000000000000000000000000",
             "0x480a7ffd7fff8000",
@@ -1679,7 +1756,7 @@
             "0x480a7ffc7fff8000",
             "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffd98",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffd5a",
             "0x480680017fff8000",
             "0x1",
             "0x400680017fff7fff",
@@ -1749,7 +1826,7 @@
             "0x480a7ffc7fff8000",
             "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffcfb",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffcbd",
             "0x208b7fff7fff7ffe",
             "0x480280027ffb8000",
             "0x480280027ffd8000",
@@ -1792,7 +1869,7 @@
             "0x482480017ffb8000",
             "0x1",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffcbf",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffc81",
             "0x482480017fff8000",
             "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffffc",
             "0x40137fff7fff8000",
@@ -1803,14 +1880,14 @@
             "0x5",
             "0x480a80007fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffcc5",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffc87",
             "0x48127ffd7fff8000",
             "0x480a7ff97fff8000",
             "0x480a7ffb7fff8000",
             "0x480a7ffc7fff8000",
             "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffcbe",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffc80",
             "0x48127ffd7fff8000",
             "0x480680017fff8000",
             "0x0",
@@ -1861,7 +1938,7 @@
             "0x480a7ffc7fff8000",
             "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffc7f",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffc41",
             "0x208b7fff7fff7ffe",
             "0x480280027ffb8000",
             "0x480280027ffd8000",
@@ -1896,7 +1973,7 @@
             "0x480a7ffc7fff8000",
             "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffc5c",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffc1e",
             "0x48127ffd7fff8000",
             "0x480a7ff97fff8000",
             "0x480a7ffa7fff8000",
@@ -1939,7 +2016,7 @@
             "0x480a7ff87fff8000",
             "0x480a7ff97fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffc31",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffbf3",
             "0x40137ffe7fff8000",
             "0x48127ffd7fff8000",
             "0x480a7ffa7fff8000",
@@ -1947,23 +2024,23 @@
             "0x480a7ffc7fff8000",
             "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffc29",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffbeb",
             "0x40137fff7fff8001",
             "0x40137ffe7fff8002",
             "0x40137ffd7fff8003",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffc06",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffbc8",
             "0x40137fff7fff8004",
             "0x480a80047fff8000",
             "0x48127ff07fff8000",
             "0x480a80007fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffc09",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffbcb",
             "0x482a800080048000",
             "0x480a80017fff8000",
             "0x480a80027fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffc04",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffbc6",
             "0x480a80037fff8000",
             "0x482a800280008000",
             "0x480a80047fff8000",
@@ -2007,7 +2084,7 @@
             "0x48127ff87fff8000",
             "0x208b7fff7fff7ffe",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffbe8",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffbaa",
             "0x480a7ffb7fff8000",
             "0x480a7ffc7fff8000",
             "0x480a7ffd7fff8000",
@@ -2015,7 +2092,7 @@
             "0x0",
             "0x48127ffb7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffbe5",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffba7",
             "0x48127ffd7fff8000",
             "0x208b7fff7fff7ffe",
             "0x482680017ffd8000",
@@ -2040,7 +2117,7 @@
             "0x480a7ffc7fff8000",
             "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffc48",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffc0a",
             "0x208b7fff7fff7ffe",
             "0x482680017ffd8000",
             "0x1",
@@ -2067,7 +2144,7 @@
             "0x480a7ffc7fff8000",
             "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffbd5",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffb97",
             "0x208b7fff7fff7ffe",
             "0x40780017fff7fff",
             "0x1",
@@ -2119,11 +2196,11 @@
             "0x480680017fff8000",
             "0x27",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffd4a",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffd32",
             "0x480680017fff8000",
             "0x1",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffd38",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffd20",
             "0x400680017fff7fff",
             "0x27",
             "0x48127ffc7fff8000",
@@ -2155,7 +2232,7 @@
             "0x480a7ffc7fff8000",
             "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffceb",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffcd3",
             "0x208b7fff7fff7ffe",
             "0x40780017fff7fff",
             "0x1",
@@ -2239,7 +2316,7 @@
             "0x482680017ffd8000",
             "0x3",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffb05",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffac7",
             "0x48127ffd7fff8000",
             "0x480680017fff8000",
             "0x0",
@@ -2257,7 +2334,7 @@
             "0x482680017ffd8000",
             "0x3",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffaff",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffac1",
             "0x48127ffd7fff8000",
             "0x480680017fff8000",
             "0x0",
@@ -2411,7 +2488,7 @@
             "0x482680017ffd8000",
             "0x800000000000011000000000000000000000000000000000000000000000000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffa54",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffa16",
             "0x482480017fff8000",
             "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffffe",
             "0x40137fff7fff8000",
@@ -2422,7 +2499,7 @@
             "0x3",
             "0x480a80007fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffa4e",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffa10",
             "0x48127ffd7fff8000",
             "0x208b7fff7fff7ffe",
             "0x482680017ffd8000",
@@ -2451,15 +2528,15 @@
             "0x480a7ff97fff8000",
             "0x480a7ffa7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffa94",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffa56",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffa5f",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffa21",
             "0x480a7ffb7fff8000",
             "0x480a7ffc7fff8000",
             "0x480680017fff8000",
             "0x0",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffa24",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff9e6",
             "0x482480017fff8000",
             "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffffd",
             "0x40137fff7fff8000",
@@ -2471,7 +2548,7 @@
             "0x4",
             "0x480a80007fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffa1d",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff9df",
             "0x208b7fff7fff7ffe",
             "0x40780017fff7fff",
             "0x3",
@@ -2487,7 +2564,7 @@
             "0x480a7ffc7fff8000",
             "0x480a7ffb7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff9f8",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff9ba",
             "0x480a80017fff8000",
             "0x4829800080008002",
             "0x480a80007fff8000",
@@ -2519,7 +2596,7 @@
             "0x208b7fff7fff7ffe",
             "0x480a7ffc7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffa2b",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff9ed",
             "0x400a7ffd7fff7fff",
             "0x48127ffe7fff8000",
             "0x208b7fff7fff7ffe",
@@ -2543,7 +2620,7 @@
             "0x208b7fff7fff7ffe",
             "0x480a7ffc7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffa21",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff9e3",
             "0x400a7ffd7fff7fff",
             "0x48127ffe7fff8000",
             "0x208b7fff7fff7ffe",
@@ -2567,7 +2644,7 @@
             "0x208b7fff7fff7ffe",
             "0x480a7ffc7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff9f4",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff9b6",
             "0x400a7ffd7fff7fff",
             "0x48127ffe7fff8000",
             "0x208b7fff7fff7ffe",
@@ -2591,7 +2668,7 @@
             "0x208b7fff7fff7ffe",
             "0x480a7ff67fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffffa1a",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff9dc",
             "0x480080007fff8000",
             "0x480080017ffe8000",
             "0x480080027ffd8000",
@@ -2613,17 +2690,17 @@
             "0x12c",
             "0x48127ffb7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff9f2",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff9b4",
             "0x480680017fff8000",
             "0x137",
             "0x48127ff67fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff9ed",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff9af",
             "0x480680017fff8000",
             "0x142",
             "0x48127ff17fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff9e8",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff9aa",
             "0x480a7ff77fff8000",
             "0x208b7fff7fff7ffe",
             "0x482680017ffd8000",
@@ -2652,7 +2729,7 @@
             "0x208b7fff7fff7ffe",
             "0x480a7ffc7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff9dd",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff99f",
             "0x400180007fff7ffd",
             "0x48127ffe7fff8000",
             "0x208b7fff7fff7ffe",
@@ -2680,13 +2757,13 @@
             "0x480680017fff8000",
             "0x0",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff9af",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff971",
             "0x480680017fff8000",
             "0xf",
             "0x480680017fff8000",
             "0x1",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff9a9",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff96b",
             "0x480a7ffd7fff8000",
             "0x208b7fff7fff7ffe",
             "0x402b7ffd7ffc7ffd",
@@ -2708,7 +2785,7 @@
             "0x40780017fff7fff",
             "0x1",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff912",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff8d4",
             "0x40137fff7fff8000",
             "0x4003800080007ffb",
             "0x4003800180007ffc",
@@ -2722,7 +2799,7 @@
             "0x4828800080007ffc",
             "0x480a80007fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff922",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff8e4",
             "0x48127ffd7fff8000",
             "0x480a7ff97fff8000",
             "0x208b7fff7fff7ffe",
@@ -2731,11 +2808,11 @@
             "0x2691cb735b18f3f656c3b82bd97a32b65d15019b64117513f8604d1e06fe58b",
             "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff8fe",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff8c0",
             "0x480a7ffc7fff8000",
             "0x48127ffe7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff9a5",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff98d",
             "0x48127fe17fff8000",
             "0x48127ffd7fff8000",
             "0x48127ffd7fff8000",
@@ -2748,12 +2825,12 @@
             "0x480a7ffa7fff8000",
             "0x48127ffe7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff963",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff925",
             "0x48127ffe7fff8000",
             "0x482480017ff78000",
             "0x1",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff95e",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff920",
             "0x48127ffe7fff8000",
             "0x48127fee7fff8000",
             "0x48127fee7fff8000",
@@ -2769,12 +2846,12 @@
             "0x48127ffe7fff8000",
             "0x480a7ffc7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff956",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff918",
             "0x482480017ff88000",
             "0x1",
             "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff951",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff913",
             "0x48127ff07fff8000",
             "0x48127ff07fff8000",
             "0x208b7fff7fff7ffe",
@@ -2791,12 +2868,12 @@
             "0x48127ffe7fff8000",
             "0x480a7ffc7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff940",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff902",
             "0x482480017ff88000",
             "0x1",
             "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff93b",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff8fd",
             "0x48127ff07fff8000",
             "0x48127ff07fff8000",
             "0x208b7fff7fff7ffe",
@@ -2847,12 +2924,12 @@
             "0x48127ffd7fff8000",
             "0x480a7ffc7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff95d",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff945",
             "0x48127ffe7fff8000",
             "0x48127ff77fff8000",
             "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff958",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff940",
             "0x48127fed7fff8000",
             "0x48127fed7fff8000",
             "0x48127fed7fff8000",
@@ -2929,7 +3006,7 @@
             "0x480680017fff8000",
             "0x4b5810004d9272776dec83ecc20c19353453b956e594188890b48467cb53c19",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff95a",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff942",
             "0x480a7ffa7fff8000",
             "0x480a7ffb7fff8000",
             "0x480a7ffc7fff8000",
@@ -2959,7 +3036,7 @@
             "0x208b7fff7fff7ffe",
             "0x480a7ffc7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff888",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff84a",
             "0x400680017fff7ffe",
             "0x2",
             "0x48127ffd7fff8000",
@@ -3007,14 +3084,14 @@
             "0x400780017fff8001",
             "0x22",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff7ff",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff7c1",
             "0x480a7ffc7fff8000",
             "0x480a7ffd7fff8000",
             "0x480680017fff8000",
             "0x2",
             "0x48127ffb7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff928",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff910",
             "0x208b7fff7fff7ffe",
             "0x482680017ffd8000",
             "0x1",
@@ -3046,7 +3123,7 @@
             "0x480a7ffc7fff8000",
             "0x480a7ffd7fff8000",
             "0x1104800180018000",
-            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff849",
+            "0x800000000000010fffffffffffffffffffffffffffffffffffffffffffff80b",
             "0x480a7ff77fff8000",
             "0x480a7ff87fff8000",
             "0x482680017ff98000",
@@ -3454,23 +3531,61 @@
                 {
                     "accessible_scopes": [
                         "starkware.cairo.common.math",
-                        "starkware.cairo.common.math.assert_250_bit"
+                        "starkware.cairo.common.math.assert_nn"
                     ],
-                    "code": "from starkware.cairo.common.math_utils import as_int\n\n# Correctness check.\nvalue = as_int(ids.value, PRIME) % PRIME\nassert value < ids.UPPER_BOUND, f'{value} is outside of the range [0, 2**250).'\n\n# Calculation for the assertion.\nids.high, ids.low = divmod(ids.value, ids.SHIFT)",
+                    "code": "from starkware.cairo.common.math_utils import assert_integer\nassert_integer(ids.a)\nassert 0 <= ids.a % PRIME < range_check_builtin.bound, f'a = {ids.a} is out of range.'",
                     "flow_tracking_data": {
                         "ap_tracking": {
                             "group": 20,
                             "offset": 0
                         },
                         "reference_ids": {
-                            "starkware.cairo.common.math.assert_250_bit.high": 19,
-                            "starkware.cairo.common.math.assert_250_bit.low": 18,
-                            "starkware.cairo.common.math.assert_250_bit.value": 17
+                            "starkware.cairo.common.math.assert_nn.a": 17
                         }
                     }
                 }
             ],
-            "176": [
+            "170": [
+                {
+                    "accessible_scopes": [
+                        "starkware.cairo.common.math",
+                        "starkware.cairo.common.math.assert_250_bit"
+                    ],
+                    "code": "from starkware.cairo.common.math_utils import as_int\n\n# Correctness check.\nvalue = as_int(ids.value, PRIME) % PRIME\nassert value < ids.UPPER_BOUND, f'{value} is outside of the range [0, 2**250).'\n\n# Calculation for the assertion.\nids.high, ids.low = divmod(ids.value, ids.SHIFT)",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 22,
+                            "offset": 0
+                        },
+                        "reference_ids": {
+                            "starkware.cairo.common.math.assert_250_bit.high": 20,
+                            "starkware.cairo.common.math.assert_250_bit.low": 19,
+                            "starkware.cairo.common.math.assert_250_bit.value": 18
+                        }
+                    }
+                }
+            ],
+            "183": [
+                {
+                    "accessible_scopes": [
+                        "starkware.cairo.common.math",
+                        "starkware.cairo.common.math.split_felt"
+                    ],
+                    "code": "from starkware.cairo.common.math_utils import assert_integer\nassert ids.MAX_HIGH < 2**128 and ids.MAX_LOW < 2**128\nassert PRIME - 1 == ids.MAX_HIGH * 2**128 + ids.MAX_LOW\nassert_integer(ids.value)\nids.low = ids.value & ((1 << 128) - 1)\nids.high = ids.value >> 128",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 23,
+                            "offset": 0
+                        },
+                        "reference_ids": {
+                            "starkware.cairo.common.math.split_felt.high": 23,
+                            "starkware.cairo.common.math.split_felt.low": 22,
+                            "starkware.cairo.common.math.split_felt.value": 21
+                        }
+                    }
+                }
+            ],
+            "214": [
                 {
                     "accessible_scopes": [
                         "starkware.starknet.common.storage",
@@ -3479,17 +3594,17 @@
                     "code": "# Verify the assumptions on the relationship between 2**250, ADDR_BOUND and PRIME.\nADDR_BOUND = ids.ADDR_BOUND % PRIME\nassert (2**250 < ADDR_BOUND <= 2**251) and (2 * 2**250 < PRIME) and (\n        ADDR_BOUND * 2 > PRIME), \\\n    'normalize_address() cannot be used with the current constants.'\nids.is_small = 1 if ids.addr < ADDR_BOUND else 0",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 21,
+                            "group": 24,
                             "offset": 1
                         },
                         "reference_ids": {
-                            "starkware.starknet.common.storage.normalize_address.addr": 20,
-                            "starkware.starknet.common.storage.normalize_address.is_small": 21
+                            "starkware.starknet.common.storage.normalize_address.addr": 24,
+                            "starkware.starknet.common.storage.normalize_address.is_small": 25
                         }
                     }
                 }
             ],
-            "194": [
+            "232": [
                 {
                     "accessible_scopes": [
                         "starkware.starknet.common.storage",
@@ -3498,17 +3613,17 @@
                     "code": "ids.is_250 = 1 if ids.addr < 2**250 else 0",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 21,
+                            "group": 24,
                             "offset": 2
                         },
                         "reference_ids": {
-                            "starkware.starknet.common.storage.normalize_address.addr": 20,
-                            "starkware.starknet.common.storage.normalize_address.is_250": 22
+                            "starkware.starknet.common.storage.normalize_address.addr": 24,
+                            "starkware.starknet.common.storage.normalize_address.is_250": 26
                         }
                     }
                 }
             ],
-            "301": [
+            "339": [
                 {
                     "accessible_scopes": [
                         "starkware.cairo.common.ec",
@@ -3517,19 +3632,19 @@
                     "code": "from starkware.crypto.signature.signature import ALPHA, BETA, FIELD_PRIME\nfrom starkware.python.math_utils import random_ec_point\nfrom starkware.python.utils import to_bytes\n\n# Define a seed for random_ec_point that's dependent on all the input, so that:\n#   (1) The added point s is deterministic.\n#   (2) It's hard to choose inputs for which the builtin will fail.\nseed = b\"\".join(map(to_bytes, [ids.p.x, ids.p.y, ids.m, ids.q.x, ids.q.y]))\nids.s.x, ids.s.y = random_ec_point(FIELD_PRIME, ALPHA, BETA, seed)",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 27,
+                            "group": 30,
                             "offset": 2
                         },
                         "reference_ids": {
-                            "starkware.cairo.common.ec.ec_op.m": 24,
-                            "starkware.cairo.common.ec.ec_op.p": 23,
-                            "starkware.cairo.common.ec.ec_op.q": 25,
-                            "starkware.cairo.common.ec.ec_op.s": 26
+                            "starkware.cairo.common.ec.ec_op.m": 28,
+                            "starkware.cairo.common.ec.ec_op.p": 27,
+                            "starkware.cairo.common.ec.ec_op.q": 29,
+                            "starkware.cairo.common.ec.ec_op.s": 30
                         }
                     }
                 }
             ],
-            "334": [
+            "372": [
                 {
                     "accessible_scopes": [
                         "starkware.starknet.common.messages",
@@ -3538,16 +3653,16 @@
                     "code": "syscall_handler.send_message_to_l1(segments=segments, syscall_ptr=ids.syscall_ptr)",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 31,
+                            "group": 34,
                             "offset": 1
                         },
                         "reference_ids": {
-                            "starkware.starknet.common.messages.send_message_to_l1.syscall_ptr": 27
+                            "starkware.starknet.common.messages.send_message_to_l1.syscall_ptr": 31
                         }
                     }
                 }
             ],
-            "518": [
+            "556": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -3558,14 +3673,32 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 48,
+                            "group": 51,
                             "offset": 13
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "533": [
+            "580": [
+                {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.split_felt_wrapper"
+                    ],
+                    "code": "memory[ap] = segments.add()",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 53,
+                            "offset": 27
+                        },
+                        "reference_ids": {}
+                    }
+                }
+            ],
+            "595": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -3576,14 +3709,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 50,
+                            "group": 55,
                             "offset": 2
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "553": [
+            "615": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -3594,14 +3727,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 52,
+                            "group": 57,
                             "offset": 4
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "566": [
+            "628": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -3612,14 +3745,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 54,
+                            "group": 59,
                             "offset": 0
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "633": [
+            "695": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -3630,14 +3763,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 58,
+                            "group": 63,
                             "offset": 8
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "646": [
+            "708": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -3647,17 +3780,17 @@
                     "code": "from starkware.python.math_utils import isqrt\nvalue = ids.value % PRIME\nassert value < 2 ** 250, f\"value={value} is outside of the range [0, 2**250).\"\nassert 2 ** 250 < PRIME\nids.root = isqrt(value)",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 59,
+                            "group": 64,
                             "offset": 1
                         },
                         "reference_ids": {
-                            "__main__.sqrt.root": 29,
-                            "__main__.sqrt.value": 28
+                            "__main__.sqrt.root": 33,
+                            "__main__.sqrt.value": 32
                         }
                     }
                 }
             ],
-            "657": [
+            "719": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -3668,14 +3801,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 60,
+                            "group": 65,
                             "offset": 7
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "677": [
+            "739": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -3686,14 +3819,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 62,
+                            "group": 67,
                             "offset": 0
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "732": [
+            "794": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -3704,14 +3837,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 68,
+                            "group": 73,
                             "offset": 0
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "762": [
+            "824": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -3722,38 +3855,20 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 70,
+                            "group": 75,
                             "offset": 15
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "784": [
+            "846": [
                 {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
                         "__wrappers__",
                         "__wrappers__.test_long_retdata_encode_return"
-                    ],
-                    "code": "memory[ap] = segments.add()",
-                    "flow_tracking_data": {
-                        "ap_tracking": {
-                            "group": 72,
-                            "offset": 0
-                        },
-                        "reference_ids": {}
-                    }
-                }
-            ],
-            "883": [
-                {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__wrappers__",
-                        "__wrappers__.test_nested_library_call_encode_return"
                     ],
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
@@ -3765,7 +3880,25 @@
                     }
                 }
             ],
-            "988": [
+            "945": [
+                {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.test_nested_library_call_encode_return"
+                    ],
+                    "code": "memory[ap] = segments.add()",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 82,
+                            "offset": 0
+                        },
+                        "reference_ids": {}
+                    }
+                }
+            ],
+            "1050": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -3776,14 +3909,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 82,
+                            "group": 87,
                             "offset": 28
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "1094": [
+            "1156": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -3794,14 +3927,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 89,
+                            "group": 94,
                             "offset": 23
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "1117": [
+            "1179": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -3812,14 +3945,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 91,
+                            "group": 96,
                             "offset": 11
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "1137": [
+            "1199": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -3830,14 +3963,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 93,
+                            "group": 98,
                             "offset": 0
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "1204": [
+            "1266": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -3848,14 +3981,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 96,
+                            "group": 101,
                             "offset": 126
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "1225": [
+            "1287": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -3866,14 +3999,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 99,
+                            "group": 104,
                             "offset": 0
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "1271": [
+            "1333": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -3884,14 +4017,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 103,
+                            "group": 108,
                             "offset": 2
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "1358": [
+            "1420": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -3902,14 +4035,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 107,
+                            "group": 112,
                             "offset": 0
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "1403": [
+            "1465": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -3920,14 +4053,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 111,
+                            "group": 116,
                             "offset": 3
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "1432": [
+            "1494": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -3938,56 +4071,20 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 115,
+                            "group": 120,
                             "offset": 0
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "1457": [
+            "1519": [
                 {
                     "accessible_scopes": [
                         "__main__",
                         "__main__",
                         "__wrappers__",
                         "__wrappers__.recurse"
-                    ],
-                    "code": "memory[ap] = segments.add()",
-                    "flow_tracking_data": {
-                        "ap_tracking": {
-                            "group": 119,
-                            "offset": 0
-                        },
-                        "reference_ids": {}
-                    }
-                }
-            ],
-            "1502": [
-                {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__wrappers__",
-                        "__wrappers__.recursive_syscall"
-                    ],
-                    "code": "memory[ap] = segments.add()",
-                    "flow_tracking_data": {
-                        "ap_tracking": {
-                            "group": 122,
-                            "offset": 0
-                        },
-                        "reference_ids": {}
-                    }
-                }
-            ],
-            "1541": [
-                {
-                    "accessible_scopes": [
-                        "__main__",
-                        "__main__",
-                        "__wrappers__",
-                        "__wrappers__.test_write_and_transfer_encode_return"
                     ],
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
@@ -3999,7 +4096,43 @@
                     }
                 }
             ],
-            "1598": [
+            "1564": [
+                {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.recursive_syscall"
+                    ],
+                    "code": "memory[ap] = segments.add()",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 127,
+                            "offset": 0
+                        },
+                        "reference_ids": {}
+                    }
+                }
+            ],
+            "1603": [
+                {
+                    "accessible_scopes": [
+                        "__main__",
+                        "__main__",
+                        "__wrappers__",
+                        "__wrappers__.test_write_and_transfer_encode_return"
+                    ],
+                    "code": "memory[ap] = segments.add()",
+                    "flow_tracking_data": {
+                        "ap_tracking": {
+                            "group": 129,
+                            "offset": 0
+                        },
+                        "reference_ids": {}
+                    }
+                }
+            ],
+            "1660": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -4010,14 +4143,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 129,
+                            "group": 134,
                             "offset": 12
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "1622": [
+            "1684": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -4028,14 +4161,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 131,
+                            "group": 136,
                             "offset": 12
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "1646": [
+            "1708": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -4046,14 +4179,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 133,
+                            "group": 138,
                             "offset": 12
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "1707": [
+            "1769": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -4064,14 +4197,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 135,
+                            "group": 140,
                             "offset": 45
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "1731": [
+            "1793": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -4082,14 +4215,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 137,
+                            "group": 142,
                             "offset": 12
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "1762": [
+            "1824": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -4100,14 +4233,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 139,
+                            "group": 144,
                             "offset": 18
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "1894": [
+            "1956": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -4118,14 +4251,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 147,
+                            "group": 152,
                             "offset": 145
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "1943": [
+            "2005": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -4136,14 +4269,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 149,
+                            "group": 154,
                             "offset": 161
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "1974": [
+            "2036": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -4154,14 +4287,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 151,
+                            "group": 156,
                             "offset": 35
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "2014": [
+            "2076": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -4172,14 +4305,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 155,
+                            "group": 160,
                             "offset": 0
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "2057": [
+            "2119": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -4190,14 +4323,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 157,
+                            "group": 162,
                             "offset": 153
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "2091": [
+            "2153": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -4208,14 +4341,14 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 159,
+                            "group": 164,
                             "offset": 17
                         },
                         "reference_ids": {}
                     }
                 }
             ],
-            "2166": [
+            "2228": [
                 {
                     "accessible_scopes": [
                         "__main__",
@@ -4226,7 +4359,7 @@
                     "code": "memory[ap] = segments.add()",
                     "flow_tracking_data": {
                         "ap_tracking": {
-                            "group": 165,
+                            "group": 170,
                             "offset": 0
                         },
                         "reference_ids": {}
@@ -4315,7 +4448,7 @@
             },
             "__main__.MyContract.xor_counters": {
                 "decorators": [],
-                "pc": 1773,
+                "pc": 1835,
                 "type": "function"
             },
             "__main__.MyContract.xor_counters.Args": {
@@ -4368,7 +4501,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 2025,
+                "pc": 2087,
                 "type": "function"
             },
             "__main__.add_signature_to_counters.Args": {
@@ -4413,7 +4546,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1868,
+                "pc": 1930,
                 "type": "function"
             },
             "__main__.advance_counter.Args": {
@@ -4470,7 +4603,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 617,
+                "pc": 679,
                 "type": "function"
             },
             "__main__.bitwise_and.Args": {
@@ -4519,7 +4652,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 957,
+                "pc": 1019,
                 "type": "function"
             },
             "__main__.call_execute_directly.Args": {
@@ -4572,7 +4705,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1954,
+                "pc": 2016,
                 "type": "function"
             },
             "__main__.call_xor_counters.Args": {
@@ -4617,7 +4750,7 @@
                 "decorators": [
                     "constructor"
                 ],
-                "pc": 504,
+                "pc": 542,
                 "type": "function"
             },
             "__main__.constructor.Args": {
@@ -4691,7 +4824,7 @@
             },
             "__main__.ec_point.addr": {
                 "decorators": [],
-                "pc": 1846,
+                "pc": 1908,
                 "type": "function"
             },
             "__main__.ec_point.addr.Args": {
@@ -4741,7 +4874,7 @@
             },
             "__main__.ec_point.write": {
                 "decorators": [],
-                "pc": 1851,
+                "pc": 1913,
                 "type": "function"
             },
             "__main__.ec_point.write.Args": {
@@ -4788,7 +4921,7 @@
             },
             "__main__.emit_event_recurse": {
                 "decorators": [],
-                "pc": 2102,
+                "pc": 2164,
                 "type": "function"
             },
             "__main__.emit_event_recurse.Args": {
@@ -4849,7 +4982,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1395,
+                "pc": 1457,
                 "type": "function"
             },
             "__main__.fail.Args": {
@@ -4876,7 +5009,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1267,
+                "pc": 1329,
                 "type": "function"
             },
             "__main__.foo.Args": {
@@ -4939,7 +5072,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1282,
+                "pc": 1344,
                 "type": "function"
             },
             "__main__.invoke_call_chain.Args": {
@@ -5017,7 +5150,7 @@
             },
             "__main__.number_map.addr": {
                 "decorators": [],
-                "pc": 463,
+                "pc": 501,
                 "type": "function"
             },
             "__main__.number_map.addr.Args": {
@@ -5064,7 +5197,7 @@
             },
             "__main__.number_map.read": {
                 "decorators": [],
-                "pc": 477,
+                "pc": 515,
                 "type": "function"
             },
             "__main__.number_map.read.Args": {
@@ -5115,7 +5248,7 @@
             },
             "__main__.number_map.write": {
                 "decorators": [],
-                "pc": 491,
+                "pc": 529,
                 "type": "function"
             },
             "__main__.number_map.write.Args": {
@@ -5162,7 +5295,7 @@
             },
             "__main__.other_syscalls": {
                 "decorators": [],
-                "pc": 592,
+                "pc": 654,
                 "type": "function"
             },
             "__main__.other_syscalls.Args": {
@@ -5194,7 +5327,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1443,
+                "pc": 1505,
                 "type": "function"
             },
             "__main__.recurse.Args": {
@@ -5226,7 +5359,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1414,
+                "pc": 1476,
                 "type": "function"
             },
             "__main__.recursive_fail.Args": {
@@ -5258,7 +5391,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1468,
+                "pc": 1530,
                 "type": "function"
             },
             "__main__.recursive_syscall.Args": {
@@ -5307,7 +5440,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 564,
+                "pc": 626,
                 "type": "function"
             },
             "__main__.return_result.Args": {
@@ -5339,7 +5472,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 2068,
+                "pc": 2130,
                 "type": "function"
             },
             "__main__.send_message.Args": {
@@ -5376,11 +5509,52 @@
                 "destination": "starkware.starknet.common.messages.send_message_to_l1",
                 "type": "alias"
             },
+            "__main__.split_felt": {
+                "destination": "starkware.cairo.common.math.split_felt",
+                "type": "alias"
+            },
+            "__main__.split_felt_wrapper": {
+                "decorators": [
+                    "external"
+                ],
+                "pc": 567,
+                "type": "function"
+            },
+            "__main__.split_felt_wrapper.Args": {
+                "full_name": "__main__.split_felt_wrapper.Args",
+                "members": {
+                    "value": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "__main__.split_felt_wrapper.ImplicitArgs": {
+                "full_name": "__main__.split_felt_wrapper.ImplicitArgs",
+                "members": {
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "__main__.split_felt_wrapper.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "__main__.split_felt_wrapper.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
             "__main__.sqrt": {
                 "decorators": [
                     "external"
                 ],
-                "pc": 644,
+                "pc": 706,
                 "type": "function"
             },
             "__main__.sqrt.Args": {
@@ -5419,10 +5593,10 @@
                 "references": [
                     {
                         "ap_tracking_data": {
-                            "group": 59,
+                            "group": 64,
                             "offset": 1
                         },
-                        "pc": 646,
+                        "pc": 708,
                         "value": "[cast(fp, felt*)]"
                     }
                 ],
@@ -5434,10 +5608,10 @@
                 "references": [
                     {
                         "ap_tracking_data": {
-                            "group": 59,
+                            "group": 64,
                             "offset": 0
                         },
-                        "pc": 644,
+                        "pc": 706,
                         "value": "[cast(fp + (-3), felt*)]"
                     }
                 ],
@@ -5456,7 +5630,7 @@
                     "external",
                     "raw_output"
                 ],
-                "pc": 923,
+                "pc": 985,
                 "type": "function"
             },
             "__main__.test_call_contract.Args": {
@@ -5505,7 +5679,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1074,
+                "pc": 1136,
                 "type": "function"
             },
             "__main__.test_call_contract_fail_with_attr_error_msg.Args": {
@@ -5547,7 +5721,7 @@
                     "external",
                     "raw_output"
                 ],
-                "pc": 999,
+                "pc": 1061,
                 "type": "function"
             },
             "__main__.test_call_two_contracts.Args": {
@@ -5612,7 +5786,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1215,
+                "pc": 1277,
                 "type": "function"
             },
             "__main__.test_contract_address.Args": {
@@ -5669,7 +5843,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1742,
+                "pc": 1804,
                 "type": "function"
             },
             "__main__.test_count_actual_storage_changes.Args": {
@@ -5709,7 +5883,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1128,
+                "pc": 1190,
                 "type": "function"
             },
             "__main__.test_deploy.Args": {
@@ -5762,7 +5936,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1985,
+                "pc": 2047,
                 "type": "function"
             },
             "__main__.test_ec_op.Args": {
@@ -5806,7 +5980,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 2126,
+                "pc": 2188,
                 "type": "function"
             },
             "__main__.test_emit_events.Args": {
@@ -5867,7 +6041,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1585,
+                "pc": 1647,
                 "type": "function"
             },
             "__main__.test_get_block_number.Args": {
@@ -5904,7 +6078,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1609,
+                "pc": 1671,
                 "type": "function"
             },
             "__main__.test_get_block_timestamp.Args": {
@@ -5941,7 +6115,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1633,
+                "pc": 1695,
                 "type": "function"
             },
             "__main__.test_get_sequencer_address.Args": {
@@ -5978,7 +6152,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1657,
+                "pc": 1719,
                 "type": "function"
             },
             "__main__.test_get_tx_info.Args": {
@@ -6040,7 +6214,7 @@
                     "external",
                     "raw_output"
                 ],
-                "pc": 811,
+                "pc": 873,
                 "type": "function"
             },
             "__main__.test_library_call.Args": {
@@ -6089,7 +6263,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 773,
+                "pc": 835,
                 "type": "function"
             },
             "__main__.test_long_retdata.Args": {
@@ -6116,7 +6290,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 845,
+                "pc": 907,
                 "type": "function"
             },
             "__main__.test_nested_library_call.Args": {
@@ -6169,7 +6343,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1105,
+                "pc": 1167,
                 "type": "function"
             },
             "__main__.test_replace_class.Args": {
@@ -6206,7 +6380,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 668,
+                "pc": 730,
                 "type": "function"
             },
             "__main__.test_storage_read_write.Args": {
@@ -6247,7 +6421,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1179,
+                "pc": 1241,
                 "type": "function"
             },
             "__main__.test_storage_var.Args": {
@@ -6287,7 +6461,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1718,
+                "pc": 1780,
                 "type": "function"
             },
             "__main__.test_tx_version.Args": {
@@ -6324,7 +6498,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1513,
+                "pc": 1575,
                 "type": "function"
             },
             "__main__.test_write_and_transfer.Args": {
@@ -6402,7 +6576,7 @@
             },
             "__main__.two_counters.addr": {
                 "decorators": [],
-                "pc": 1794,
+                "pc": 1856,
                 "type": "function"
             },
             "__main__.two_counters.addr.Args": {
@@ -6449,7 +6623,7 @@
             },
             "__main__.two_counters.read": {
                 "decorators": [],
-                "pc": 1808,
+                "pc": 1870,
                 "type": "function"
             },
             "__main__.two_counters.read.Args": {
@@ -6500,7 +6674,7 @@
             },
             "__main__.two_counters.write": {
                 "decorators": [],
-                "pc": 1828,
+                "pc": 1890,
                 "type": "function"
             },
             "__main__.two_counters.write.Args": {
@@ -6549,7 +6723,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 544,
+                "pc": 606,
                 "type": "function"
             },
             "__main__.with_arg.Args": {
@@ -6581,7 +6755,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 529,
+                "pc": 591,
                 "type": "function"
             },
             "__main__.without_arg.Args": {
@@ -6608,7 +6782,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 705,
+                "pc": 767,
                 "type": "function"
             },
             "__main__.write_a_lot.Args": {
@@ -6649,7 +6823,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 743,
+                "pc": 805,
                 "type": "function"
             },
             "__main__.write_and_revert.Args": {
@@ -6690,7 +6864,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1905,
+                "pc": 1967,
                 "type": "function"
             },
             "__main__.xor_counters.Args": {
@@ -6739,7 +6913,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 2048,
+                "pc": 2110,
                 "type": "function"
             },
             "__wrappers__.add_signature_to_counters.Args": {
@@ -6774,7 +6948,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1883,
+                "pc": 1945,
                 "type": "function"
             },
             "__wrappers__.advance_counter.Args": {
@@ -6809,7 +6983,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 625,
+                "pc": 687,
                 "type": "function"
             },
             "__wrappers__.bitwise_and.Args": {
@@ -6844,7 +7018,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 969,
+                "pc": 1031,
                 "type": "function"
             },
             "__wrappers__.call_execute_directly.Args": {
@@ -6879,7 +7053,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1963,
+                "pc": 2025,
                 "type": "function"
             },
             "__wrappers__.call_xor_counters.Args": {
@@ -6914,7 +7088,7 @@
                 "decorators": [
                     "constructor"
                 ],
-                "pc": 510,
+                "pc": 548,
                 "type": "function"
             },
             "__wrappers__.constructor.Args": {
@@ -6949,7 +7123,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1400,
+                "pc": 1462,
                 "type": "function"
             },
             "__wrappers__.fail.Args": {
@@ -6984,7 +7158,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1268,
+                "pc": 1330,
                 "type": "function"
             },
             "__wrappers__.foo.Args": {
@@ -7019,7 +7193,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1367,
+                "pc": 1429,
                 "type": "function"
             },
             "__wrappers__.invoke_call_chain.Args": {
@@ -7048,7 +7222,7 @@
             },
             "__wrappers__.invoke_call_chain_encode_return": {
                 "decorators": [],
-                "pc": 1358,
+                "pc": 1420,
                 "type": "function"
             },
             "__wrappers__.invoke_call_chain_encode_return.Args": {
@@ -7088,7 +7262,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1451,
+                "pc": 1513,
                 "type": "function"
             },
             "__wrappers__.recurse.Args": {
@@ -7123,7 +7297,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1426,
+                "pc": 1488,
                 "type": "function"
             },
             "__wrappers__.recursive_fail.Args": {
@@ -7158,7 +7332,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1493,
+                "pc": 1555,
                 "type": "function"
             },
             "__wrappers__.recursive_syscall.Args": {
@@ -7193,7 +7367,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 575,
+                "pc": 637,
                 "type": "function"
             },
             "__wrappers__.return_result.Args": {
@@ -7222,7 +7396,7 @@
             },
             "__wrappers__.return_result_encode_return": {
                 "decorators": [],
-                "pc": 566,
+                "pc": 628,
                 "type": "function"
             },
             "__wrappers__.return_result_encode_return.Args": {
@@ -7262,7 +7436,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 2084,
+                "pc": 2146,
                 "type": "function"
             },
             "__wrappers__.send_message.Args": {
@@ -7293,11 +7467,46 @@
                 "destination": "starkware.cairo.common.memcpy.memcpy",
                 "type": "alias"
             },
+            "__wrappers__.split_felt_wrapper": {
+                "decorators": [
+                    "external"
+                ],
+                "pc": 573,
+                "type": "function"
+            },
+            "__wrappers__.split_felt_wrapper.Args": {
+                "full_name": "__wrappers__.split_felt_wrapper.Args",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.split_felt_wrapper.ImplicitArgs": {
+                "full_name": "__wrappers__.split_felt_wrapper.ImplicitArgs",
+                "members": {},
+                "size": 0,
+                "type": "struct"
+            },
+            "__wrappers__.split_felt_wrapper.Return": {
+                "cairo_type": "(syscall_ptr: felt, pedersen_ptr: felt, range_check_ptr: felt, bitwise_ptr: felt, ec_op_ptr: felt, size: felt, retdata: felt*)",
+                "type": "type_definition"
+            },
+            "__wrappers__.split_felt_wrapper.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "__wrappers__.split_felt_wrapper.__wrapped_func": {
+                "destination": "__main__.split_felt_wrapper",
+                "type": "alias"
+            },
+            "__wrappers__.split_felt_wrapper_encode_return.memcpy": {
+                "destination": "starkware.cairo.common.memcpy.memcpy",
+                "type": "alias"
+            },
             "__wrappers__.sqrt": {
                 "decorators": [
                     "external"
                 ],
-                "pc": 650,
+                "pc": 712,
                 "type": "function"
             },
             "__wrappers__.sqrt.Args": {
@@ -7333,7 +7542,7 @@
                     "external",
                     "raw_output"
                 ],
-                "pc": 931,
+                "pc": 993,
                 "type": "function"
             },
             "__wrappers__.test_call_contract.Args": {
@@ -7368,7 +7577,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1086,
+                "pc": 1148,
                 "type": "function"
             },
             "__wrappers__.test_call_contract_fail_with_attr_error_msg.Args": {
@@ -7404,7 +7613,7 @@
                     "external",
                     "raw_output"
                 ],
-                "pc": 1036,
+                "pc": 1098,
                 "type": "function"
             },
             "__wrappers__.test_call_two_contracts.Args": {
@@ -7439,7 +7648,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1234,
+                "pc": 1296,
                 "type": "function"
             },
             "__wrappers__.test_contract_address.Args": {
@@ -7468,7 +7677,7 @@
             },
             "__wrappers__.test_contract_address_encode_return": {
                 "decorators": [],
-                "pc": 1225,
+                "pc": 1287,
                 "type": "function"
             },
             "__wrappers__.test_contract_address_encode_return.Args": {
@@ -7508,7 +7717,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1757,
+                "pc": 1819,
                 "type": "function"
             },
             "__wrappers__.test_count_actual_storage_changes.Args": {
@@ -7543,7 +7752,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1146,
+                "pc": 1208,
                 "type": "function"
             },
             "__wrappers__.test_deploy.Args": {
@@ -7572,7 +7781,7 @@
             },
             "__wrappers__.test_deploy_encode_return": {
                 "decorators": [],
-                "pc": 1137,
+                "pc": 1199,
                 "type": "function"
             },
             "__wrappers__.test_deploy_encode_return.Args": {
@@ -7612,7 +7821,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 2007,
+                "pc": 2069,
                 "type": "function"
             },
             "__wrappers__.test_ec_op.Args": {
@@ -7647,7 +7856,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 2137,
+                "pc": 2199,
                 "type": "function"
             },
             "__wrappers__.test_emit_events.Args": {
@@ -7682,7 +7891,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1591,
+                "pc": 1653,
                 "type": "function"
             },
             "__wrappers__.test_get_block_number.Args": {
@@ -7717,7 +7926,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1615,
+                "pc": 1677,
                 "type": "function"
             },
             "__wrappers__.test_get_block_timestamp.Args": {
@@ -7752,7 +7961,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1639,
+                "pc": 1701,
                 "type": "function"
             },
             "__wrappers__.test_get_sequencer_address.Args": {
@@ -7787,7 +7996,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1694,
+                "pc": 1756,
                 "type": "function"
             },
             "__wrappers__.test_get_tx_info.Args": {
@@ -7823,7 +8032,7 @@
                     "external",
                     "raw_output"
                 ],
-                "pc": 819,
+                "pc": 881,
                 "type": "function"
             },
             "__wrappers__.test_library_call.Args": {
@@ -7858,7 +8067,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 797,
+                "pc": 859,
                 "type": "function"
             },
             "__wrappers__.test_long_retdata.Args": {
@@ -7887,7 +8096,7 @@
             },
             "__wrappers__.test_long_retdata_encode_return": {
                 "decorators": [],
-                "pc": 784,
+                "pc": 846,
                 "type": "function"
             },
             "__wrappers__.test_long_retdata_encode_return.Args": {
@@ -7927,7 +8136,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 892,
+                "pc": 954,
                 "type": "function"
             },
             "__wrappers__.test_nested_library_call.Args": {
@@ -7956,7 +8165,7 @@
             },
             "__wrappers__.test_nested_library_call_encode_return": {
                 "decorators": [],
-                "pc": 883,
+                "pc": 945,
                 "type": "function"
             },
             "__wrappers__.test_nested_library_call_encode_return.Args": {
@@ -7996,7 +8205,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1110,
+                "pc": 1172,
                 "type": "function"
             },
             "__wrappers__.test_replace_class.Args": {
@@ -8031,7 +8240,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 686,
+                "pc": 748,
                 "type": "function"
             },
             "__wrappers__.test_storage_read_write.Args": {
@@ -8060,7 +8269,7 @@
             },
             "__wrappers__.test_storage_read_write_encode_return": {
                 "decorators": [],
-                "pc": 677,
+                "pc": 739,
                 "type": "function"
             },
             "__wrappers__.test_storage_read_write_encode_return.Args": {
@@ -8100,7 +8309,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1198,
+                "pc": 1260,
                 "type": "function"
             },
             "__wrappers__.test_storage_var.Args": {
@@ -8135,7 +8344,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1724,
+                "pc": 1786,
                 "type": "function"
             },
             "__wrappers__.test_tx_version.Args": {
@@ -8170,7 +8379,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1560,
+                "pc": 1622,
                 "type": "function"
             },
             "__wrappers__.test_write_and_transfer.Args": {
@@ -8199,7 +8408,7 @@
             },
             "__wrappers__.test_write_and_transfer_encode_return": {
                 "decorators": [],
-                "pc": 1541,
+                "pc": 1603,
                 "type": "function"
             },
             "__wrappers__.test_write_and_transfer_encode_return.Args": {
@@ -8239,7 +8448,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 547,
+                "pc": 609,
                 "type": "function"
             },
             "__wrappers__.with_arg.Args": {
@@ -8274,7 +8483,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 530,
+                "pc": 592,
                 "type": "function"
             },
             "__wrappers__.without_arg.Args": {
@@ -8309,7 +8518,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 724,
+                "pc": 786,
                 "type": "function"
             },
             "__wrappers__.write_a_lot.Args": {
@@ -8344,7 +8553,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 754,
+                "pc": 816,
                 "type": "function"
             },
             "__wrappers__.write_and_revert.Args": {
@@ -8379,7 +8588,7 @@
                 "decorators": [
                     "external"
                 ],
-                "pc": 1931,
+                "pc": 1993,
                 "type": "function"
             },
             "__wrappers__.xor_counters.Args": {
@@ -8445,7 +8654,7 @@
             },
             "starkware.cairo.common.bitwise.bitwise_xor": {
                 "decorators": [],
-                "pc": 214,
+                "pc": 252,
                 "type": "function"
             },
             "starkware.cairo.common.bitwise.bitwise_xor.Args": {
@@ -8734,7 +8943,7 @@
             },
             "starkware.cairo.common.ec.assert_on_curve": {
                 "decorators": [],
-                "pc": 220,
+                "pc": 258,
                 "type": "function"
             },
             "starkware.cairo.common.ec.assert_on_curve.Args": {
@@ -8764,7 +8973,7 @@
             },
             "starkware.cairo.common.ec.ec_add": {
                 "decorators": [],
-                "pc": 256,
+                "pc": 294,
                 "type": "function"
             },
             "starkware.cairo.common.ec.ec_add.Args": {
@@ -8798,7 +9007,7 @@
             },
             "starkware.cairo.common.ec.ec_double": {
                 "decorators": [],
-                "pc": 233,
+                "pc": 271,
                 "type": "function"
             },
             "starkware.cairo.common.ec.ec_double.Args": {
@@ -8828,7 +9037,7 @@
             },
             "starkware.cairo.common.ec.ec_op": {
                 "decorators": [],
-                "pc": 293,
+                "pc": 331,
                 "type": "function"
             },
             "starkware.cairo.common.ec.ec_op.Args": {
@@ -8875,10 +9084,10 @@
                 "references": [
                     {
                         "ap_tracking_data": {
-                            "group": 27,
+                            "group": 30,
                             "offset": 0
                         },
-                        "pc": 293,
+                        "pc": 331,
                         "value": "[cast(fp + (-5), felt*)]"
                     }
                 ],
@@ -8890,10 +9099,10 @@
                 "references": [
                     {
                         "ap_tracking_data": {
-                            "group": 27,
+                            "group": 30,
                             "offset": 0
                         },
-                        "pc": 293,
+                        "pc": 331,
                         "value": "[cast(fp + (-7), starkware.cairo.common.ec_point.EcPoint*)]"
                     }
                 ],
@@ -8905,10 +9114,10 @@
                 "references": [
                     {
                         "ap_tracking_data": {
-                            "group": 27,
+                            "group": 30,
                             "offset": 0
                         },
-                        "pc": 293,
+                        "pc": 331,
                         "value": "[cast(fp + (-4), starkware.cairo.common.ec_point.EcPoint*)]"
                     }
                 ],
@@ -8920,10 +9129,10 @@
                 "references": [
                     {
                         "ap_tracking_data": {
-                            "group": 27,
+                            "group": 30,
                             "offset": 2
                         },
-                        "pc": 301,
+                        "pc": 339,
                         "value": "[cast(fp, starkware.cairo.common.ec_point.EcPoint*)]"
                     }
                 ],
@@ -9020,7 +9229,7 @@
             },
             "starkware.cairo.common.hash_state.hash_felts": {
                 "decorators": [],
-                "pc": 421,
+                "pc": 459,
                 "type": "function"
             },
             "starkware.cairo.common.hash_state.hash_felts.Args": {
@@ -9059,7 +9268,7 @@
             },
             "starkware.cairo.common.hash_state.hash_felts_no_padding": {
                 "decorators": [],
-                "pc": 396,
+                "pc": 434,
                 "type": "function"
             },
             "starkware.cairo.common.hash_state.hash_felts_no_padding.Args": {
@@ -9120,12 +9329,12 @@
                 "value": 1
             },
             "starkware.cairo.common.hash_state.hash_felts_no_padding.hash_loop": {
-                "pc": 409,
+                "pc": 447,
                 "type": "label"
             },
             "starkware.cairo.common.hash_state.hash_finalize": {
                 "decorators": [],
-                "pc": 390,
+                "pc": 428,
                 "type": "function"
             },
             "starkware.cairo.common.hash_state.hash_finalize.Args": {
@@ -9160,7 +9369,7 @@
             },
             "starkware.cairo.common.hash_state.hash_init": {
                 "decorators": [],
-                "pc": 337,
+                "pc": 375,
                 "type": "function"
             },
             "starkware.cairo.common.hash_state.hash_init.Args": {
@@ -9185,7 +9394,7 @@
             },
             "starkware.cairo.common.hash_state.hash_update": {
                 "decorators": [],
-                "pc": 347,
+                "pc": 385,
                 "type": "function"
             },
             "starkware.cairo.common.hash_state.hash_update.Args": {
@@ -9228,7 +9437,7 @@
             },
             "starkware.cairo.common.hash_state.hash_update_single": {
                 "decorators": [],
-                "pc": 363,
+                "pc": 401,
                 "type": "function"
             },
             "starkware.cairo.common.hash_state.hash_update_single.Args": {
@@ -9267,7 +9476,7 @@
             },
             "starkware.cairo.common.hash_state.hash_update_with_hashchain": {
                 "decorators": [],
-                "pc": 379,
+                "pc": 417,
                 "type": "function"
             },
             "starkware.cairo.common.hash_state.hash_update_with_hashchain.Args": {
@@ -9359,7 +9568,7 @@
                 "decorators": [
                     "known_ap_change"
                 ],
-                "pc": 161,
+                "pc": 170,
                 "type": "function"
             },
             "starkware.cairo.common.math.assert_250_bit.Args": {
@@ -9410,10 +9619,10 @@
                 "references": [
                     {
                         "ap_tracking_data": {
-                            "group": 20,
+                            "group": 22,
                             "offset": 0
                         },
-                        "pc": 161,
+                        "pc": 170,
                         "value": "[cast([fp + (-4)] + 1, felt*)]"
                     }
                 ],
@@ -9425,10 +9634,10 @@
                 "references": [
                     {
                         "ap_tracking_data": {
-                            "group": 20,
+                            "group": 22,
                             "offset": 0
                         },
-                        "pc": 161,
+                        "pc": 170,
                         "value": "[cast([fp + (-4)], felt*)]"
                     }
                 ],
@@ -9440,10 +9649,189 @@
                 "references": [
                     {
                         "ap_tracking_data": {
+                            "group": 22,
+                            "offset": 0
+                        },
+                        "pc": 170,
+                        "value": "[cast(fp + (-3), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "starkware.cairo.common.math.assert_le": {
+                "decorators": [],
+                "pc": 165,
+                "type": "function"
+            },
+            "starkware.cairo.common.math.assert_le.Args": {
+                "full_name": "starkware.cairo.common.math.assert_le.Args",
+                "members": {
+                    "a": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    },
+                    "b": {
+                        "cairo_type": "felt",
+                        "offset": 1
+                    }
+                },
+                "size": 2,
+                "type": "struct"
+            },
+            "starkware.cairo.common.math.assert_le.ImplicitArgs": {
+                "full_name": "starkware.cairo.common.math.assert_le.ImplicitArgs",
+                "members": {
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.cairo.common.math.assert_le.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "starkware.cairo.common.math.assert_le.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "starkware.cairo.common.math.assert_nn": {
+                "decorators": [],
+                "pc": 161,
+                "type": "function"
+            },
+            "starkware.cairo.common.math.assert_nn.Args": {
+                "full_name": "starkware.cairo.common.math.assert_nn.Args",
+                "members": {
+                    "a": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.cairo.common.math.assert_nn.ImplicitArgs": {
+                "full_name": "starkware.cairo.common.math.assert_nn.ImplicitArgs",
+                "members": {
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.cairo.common.math.assert_nn.Return": {
+                "cairo_type": "()",
+                "type": "type_definition"
+            },
+            "starkware.cairo.common.math.assert_nn.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "starkware.cairo.common.math.assert_nn.a": {
+                "cairo_type": "felt",
+                "full_name": "starkware.cairo.common.math.assert_nn.a",
+                "references": [
+                    {
+                        "ap_tracking_data": {
                             "group": 20,
                             "offset": 0
                         },
                         "pc": 161,
+                        "value": "[cast(fp + (-3), felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "starkware.cairo.common.math.split_felt": {
+                "decorators": [
+                    "known_ap_change"
+                ],
+                "pc": 183,
+                "type": "function"
+            },
+            "starkware.cairo.common.math.split_felt.Args": {
+                "full_name": "starkware.cairo.common.math.split_felt.Args",
+                "members": {
+                    "value": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.cairo.common.math.split_felt.ImplicitArgs": {
+                "full_name": "starkware.cairo.common.math.split_felt.ImplicitArgs",
+                "members": {
+                    "range_check_ptr": {
+                        "cairo_type": "felt",
+                        "offset": 0
+                    }
+                },
+                "size": 1,
+                "type": "struct"
+            },
+            "starkware.cairo.common.math.split_felt.MAX_HIGH": {
+                "type": "const",
+                "value": 10633823966279327296825105735305134080
+            },
+            "starkware.cairo.common.math.split_felt.MAX_LOW": {
+                "type": "const",
+                "value": 0
+            },
+            "starkware.cairo.common.math.split_felt.Return": {
+                "cairo_type": "(high: felt, low: felt)",
+                "type": "type_definition"
+            },
+            "starkware.cairo.common.math.split_felt.SIZEOF_LOCALS": {
+                "type": "const",
+                "value": 0
+            },
+            "starkware.cairo.common.math.split_felt.high": {
+                "cairo_type": "felt",
+                "full_name": "starkware.cairo.common.math.split_felt.high",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 23,
+                            "offset": 0
+                        },
+                        "pc": 183,
+                        "value": "[cast([fp + (-4)] + 1, felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "starkware.cairo.common.math.split_felt.low": {
+                "cairo_type": "felt",
+                "full_name": "starkware.cairo.common.math.split_felt.low",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 23,
+                            "offset": 0
+                        },
+                        "pc": 183,
+                        "value": "[cast([fp + (-4)], felt*)]"
+                    }
+                ],
+                "type": "reference"
+            },
+            "starkware.cairo.common.math.split_felt.value": {
+                "cairo_type": "felt",
+                "full_name": "starkware.cairo.common.math.split_felt.value",
+                "references": [
+                    {
+                        "ap_tracking_data": {
+                            "group": 23,
+                            "offset": 0
+                        },
+                        "pc": 183,
                         "value": "[cast(fp + (-3), felt*)]"
                     }
                 ],
@@ -9625,7 +10013,7 @@
             },
             "starkware.starknet.common.messages.send_message_to_l1": {
                 "decorators": [],
-                "pc": 328,
+                "pc": 366,
                 "type": "function"
             },
             "starkware.starknet.common.messages.send_message_to_l1.Args": {
@@ -9672,18 +10060,18 @@
                 "references": [
                     {
                         "ap_tracking_data": {
-                            "group": 31,
+                            "group": 34,
                             "offset": 0
                         },
-                        "pc": 328,
+                        "pc": 366,
                         "value": "[cast(fp + (-6), felt**)]"
                     },
                     {
                         "ap_tracking_data": {
-                            "group": 31,
+                            "group": 34,
                             "offset": 1
                         },
-                        "pc": 334,
+                        "pc": 372,
                         "value": "cast([fp + (-6)] + 4, felt*)"
                     }
                 ],
@@ -9705,7 +10093,7 @@
                 "decorators": [
                     "known_ap_change"
                 ],
-                "pc": 174,
+                "pc": 212,
                 "type": "function"
             },
             "starkware.starknet.common.storage.normalize_address.Args": {
@@ -9744,10 +10132,10 @@
                 "references": [
                     {
                         "ap_tracking_data": {
-                            "group": 21,
+                            "group": 24,
                             "offset": 0
                         },
-                        "pc": 174,
+                        "pc": 212,
                         "value": "[cast(fp + (-3), felt*)]"
                     }
                 ],
@@ -9759,10 +10147,10 @@
                 "references": [
                     {
                         "ap_tracking_data": {
-                            "group": 21,
+                            "group": 24,
                             "offset": 2
                         },
-                        "pc": 194,
+                        "pc": 232,
                         "value": "[cast(ap + (-1), felt*)]"
                     }
                 ],
@@ -9774,10 +10162,10 @@
                 "references": [
                     {
                         "ap_tracking_data": {
-                            "group": 21,
+                            "group": 24,
                             "offset": 1
                         },
-                        "pc": 176,
+                        "pc": 214,
                         "value": "[cast(ap + (-1), felt*)]"
                     }
                 ],
@@ -11363,7 +11751,7 @@
             },
             "starkware.starknet.core.os.contract_address.contract_address.get_contract_address": {
                 "decorators": [],
-                "pc": 432,
+                "pc": 470,
                 "type": "function"
             },
             "starkware.starknet.core.os.contract_address.contract_address.get_contract_address.Args": {
@@ -11591,98 +11979,130 @@
                 },
                 {
                     "ap_tracking_data": {
-                        "group": 20,
+                        "group": 22,
                         "offset": 0
                     },
-                    "pc": 161,
+                    "pc": 170,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 22,
+                        "offset": 0
+                    },
+                    "pc": 170,
                     "value": "[cast([fp + (-4)], felt*)]"
                 },
                 {
                     "ap_tracking_data": {
-                        "group": 20,
+                        "group": 22,
                         "offset": 0
                     },
-                    "pc": 161,
+                    "pc": 170,
                     "value": "[cast([fp + (-4)] + 1, felt*)]"
                 },
                 {
                     "ap_tracking_data": {
-                        "group": 21,
+                        "group": 23,
                         "offset": 0
                     },
-                    "pc": 174,
+                    "pc": 183,
                     "value": "[cast(fp + (-3), felt*)]"
                 },
                 {
                     "ap_tracking_data": {
-                        "group": 21,
-                        "offset": 1
-                    },
-                    "pc": 176,
-                    "value": "[cast(ap + (-1), felt*)]"
-                },
-                {
-                    "ap_tracking_data": {
-                        "group": 21,
-                        "offset": 2
-                    },
-                    "pc": 194,
-                    "value": "[cast(ap + (-1), felt*)]"
-                },
-                {
-                    "ap_tracking_data": {
-                        "group": 27,
+                        "group": 23,
                         "offset": 0
                     },
-                    "pc": 293,
+                    "pc": 183,
+                    "value": "[cast([fp + (-4)], felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 23,
+                        "offset": 0
+                    },
+                    "pc": 183,
+                    "value": "[cast([fp + (-4)] + 1, felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 24,
+                        "offset": 0
+                    },
+                    "pc": 212,
+                    "value": "[cast(fp + (-3), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 24,
+                        "offset": 1
+                    },
+                    "pc": 214,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 24,
+                        "offset": 2
+                    },
+                    "pc": 232,
+                    "value": "[cast(ap + (-1), felt*)]"
+                },
+                {
+                    "ap_tracking_data": {
+                        "group": 30,
+                        "offset": 0
+                    },
+                    "pc": 331,
                     "value": "[cast(fp + (-7), starkware.cairo.common.ec_point.EcPoint*)]"
                 },
                 {
                     "ap_tracking_data": {
-                        "group": 27,
+                        "group": 30,
                         "offset": 0
                     },
-                    "pc": 293,
+                    "pc": 331,
                     "value": "[cast(fp + (-5), felt*)]"
                 },
                 {
                     "ap_tracking_data": {
-                        "group": 27,
+                        "group": 30,
                         "offset": 0
                     },
-                    "pc": 293,
+                    "pc": 331,
                     "value": "[cast(fp + (-4), starkware.cairo.common.ec_point.EcPoint*)]"
                 },
                 {
                     "ap_tracking_data": {
-                        "group": 27,
+                        "group": 30,
                         "offset": 2
                     },
-                    "pc": 301,
+                    "pc": 339,
                     "value": "[cast(fp, starkware.cairo.common.ec_point.EcPoint*)]"
                 },
                 {
                     "ap_tracking_data": {
-                        "group": 31,
+                        "group": 34,
                         "offset": 0
                     },
-                    "pc": 328,
+                    "pc": 366,
                     "value": "[cast(fp + (-6), felt**)]"
                 },
                 {
                     "ap_tracking_data": {
-                        "group": 59,
+                        "group": 64,
                         "offset": 0
                     },
-                    "pc": 644,
+                    "pc": 706,
                     "value": "[cast(fp + (-3), felt*)]"
                 },
                 {
                     "ap_tracking_data": {
-                        "group": 59,
+                        "group": 64,
                         "offset": 1
                     },
-                    "pc": 646,
+                    "pc": 708,
                     "value": "[cast(fp, felt*)]"
                 }
             ]

--- a/crates/blockifier_test_utils/resources/feature_contracts/cairo0/test_contract.cairo
+++ b/crates/blockifier_test_utils/resources/feature_contracts/cairo0/test_contract.cairo
@@ -6,6 +6,7 @@ from starkware.cairo.common.bool import FALSE
 from starkware.cairo.common.cairo_builtins import BitwiseBuiltin, HashBuiltin, EcOpBuiltin
 from starkware.cairo.common.ec import ec_op
 from starkware.cairo.common.ec_point import EcPoint
+from starkware.cairo.common.math import split_felt
 from starkware.cairo.common.memcpy import memcpy
 from starkware.cairo.common.registers import get_fp_and_pc
 from starkware.starknet.common.messages import send_message_to_l1
@@ -39,6 +40,12 @@ func number_map(key: felt) -> (value: felt) {
 @constructor
 func constructor{syscall_ptr: felt*}(address: felt, value: felt) {
     storage_write(address=address, value=value);
+    return ();
+}
+
+@external
+func split_felt_wrapper{range_check_ptr} (value: felt) {
+    let (high, low) = split_felt(value);
     return ();
 }
 

--- a/crates/starknet_os/src/hint_processor/common_hint_processor.rs
+++ b/crates/starknet_os/src/hint_processor/common_hint_processor.rs
@@ -57,7 +57,6 @@ macro_rules! impl_common_hint_processor_logic {
             _vm: &mut VirtualMachine,
             _exec_scopes: &mut ExecutionScopes,
             _hint_data: &Box<dyn Any>,
-            _constants: &HashMap<String, Felt>,
         ) -> VmHintResult {
             Ok(())
         }
@@ -67,7 +66,6 @@ macro_rules! impl_common_hint_processor_logic {
             vm: &mut VirtualMachine,
             exec_scopes: &mut ExecutionScopes,
             hint_data: &Box<dyn Any>,
-            constants: &HashMap<String, Felt>,
         ) -> VmHintExtensionResult {
             if let Some(hint_processor_data) = hint_data.downcast_ref::<Cairo0Hint>() {
                 // AllHints (OS hint, aggregator hint, Cairo0 syscall) or Cairo0 core hint.
@@ -76,7 +74,7 @@ macro_rules! impl_common_hint_processor_logic {
                     exec_scopes,
                     ids_data: &hint_processor_data.ids_data,
                     ap_tracking: &hint_processor_data.ap_tracking,
-                    constants,
+                    constants: hint_processor_data.constants.as_ref(),
                 };
                 let hint_str = hint_processor_data.code.as_str();
                 if let Ok(hint) = AllHints::from_str(hint_str) {
@@ -94,12 +92,7 @@ macro_rules! impl_common_hint_processor_logic {
                     };
                 } else {
                     // Cairo0 core hint.
-                    self.get_builtin_hint_processor().execute_hint(
-                        vm,
-                        exec_scopes,
-                        hint_data,
-                        constants,
-                    )?;
+                    self.get_builtin_hint_processor().execute_hint(vm, exec_scopes, hint_data)?;
                     return Ok(HintExtension::default());
                 }
             }

--- a/crates/starknet_os_flow_tests/src/tests.rs
+++ b/crates/starknet_os_flow_tests/src/tests.rs
@@ -9,7 +9,8 @@ use blockifier_test_utils::calldata::create_calldata;
 use blockifier_test_utils::contracts::FeatureContract;
 use rstest::rstest;
 use starknet_api::abi::abi_utils::get_storage_var_address;
-use starknet_api::core::calculate_contract_address;
+use starknet_api::contract_class::{ClassInfo, SierraVersion};
+use starknet_api::core::{calculate_contract_address, ClassHash, CompiledClassHash, Nonce};
 use starknet_api::executable_transaction::{DeclareTransaction, InvokeTransaction};
 use starknet_api::execution_resources::GasAmount;
 use starknet_api::test_utils::declare::declare_tx;
@@ -29,6 +30,7 @@ use starknet_api::transaction::fields::{
     ResourceBounds,
     ValidResourceBounds,
 };
+use starknet_api::transaction::TransactionVersion;
 use starknet_api::{declare_tx_args, invoke_tx_args};
 use starknet_types_core::felt::Felt;
 
@@ -75,7 +77,7 @@ fn division(#[case] length: usize, #[case] n_parts: usize, #[case] expected_leng
     assert_eq!(actual_lengths, expected_lengths);
 }
 
-/// Scenario of declaring and deploying the test contract.
+/// Scenario of declaring and deploying the cairo1 test contract.
 #[rstest]
 #[tokio::test]
 async fn declare_deploy_scenario(#[values(1, 2)] n_blocks: usize) {
@@ -155,4 +157,92 @@ async fn declare_deploy_scenario(#[values(1, 2)] n_blocks: usize) {
 
     let perform_global_validations = true;
     test_output.perform_validations(perform_global_validations, Some(&partial_state_diff));
+}
+
+/// Scenario of declaring, deploying and invoking the cairo0 test contract.
+#[rstest]
+#[tokio::test]
+async fn declare_deploy_invoke_cairo0_scenario() {
+    // Initialize the test manager with a default initial state and get the nonce manager to help
+    // keep track of nonces.
+    let (mut test_manager, mut nonce_manager) =
+        TestManager::<DictStateReader>::new_with_default_initial_state().await;
+
+    // Declare a test contract.
+    let test_contract = FeatureContract::TestContract(CairoVersion::Cairo0);
+    // The class hash of the cairo0 test contract.
+    let class_hash = ClassHash(Felt::from_hex_unchecked(
+        "0x263c5249f44866bcc38749a4bde98bf378af6605fd586f4f128e8b2f73772ba",
+    ));
+    let compiled_class_hash = CompiledClassHash::default();
+    let declare_tx_args = declare_tx_args! {
+        sender_address: *FUNDED_ACCOUNT_ADDRESS,
+        class_hash,
+        compiled_class_hash,
+        resource_bounds: *NON_TRIVIAL_RESOURCE_BOUNDS,
+        nonce: Nonce(Felt::TWO),
+        version: TransactionVersion(Felt::ZERO),
+    };
+    let account_declare_tx = declare_tx(declare_tx_args);
+    let class_info = ClassInfo {
+        contract_class: test_contract.get_class(),
+        sierra_program_length: 0,
+        abi_length: 0,
+        sierra_version: SierraVersion::default(),
+    };
+    let tx =
+        DeclareTransaction::create(account_declare_tx, class_info, &CHAIN_ID_FOR_TESTS).unwrap();
+    // Add the transaction to the test manager.
+    test_manager.add_cairo0_declare_tx(tx, CompiledClassHash(class_hash.0));
+    let arg1 = Felt::from(88);
+    let arg2 = Felt::from(125);
+    // Deploy the test contract using the deploy contract syscall.
+    let constructor_calldata = [
+        2.into(), // constructor length
+        arg1,
+        arg2,
+    ];
+    let contract_address_salt = ContractAddressSalt(Felt::ONE);
+    let calldata: Vec<_> =
+        [class_hash.0, contract_address_salt.0].into_iter().chain(constructor_calldata).collect();
+    let deploy_contract_calldata = create_calldata(
+        *FUNDED_ACCOUNT_ADDRESS,
+        DEPLOY_CONTRACT_FUNCTION_ENTRY_POINT_NAME,
+        &calldata,
+    );
+    let invoke_tx_args = invoke_tx_args! {
+        sender_address: *FUNDED_ACCOUNT_ADDRESS,
+        nonce: nonce_manager.next(*FUNDED_ACCOUNT_ADDRESS),
+        calldata: deploy_contract_calldata,
+        resource_bounds: *NON_TRIVIAL_RESOURCE_BOUNDS,
+    };
+    let expected_contract_address = calculate_contract_address(
+        contract_address_salt,
+        class_hash,
+        &Calldata(constructor_calldata[1..].to_vec().into()),
+        *FUNDED_ACCOUNT_ADDRESS,
+    )
+    .unwrap();
+    let deploy_contract_tx = invoke_tx(invoke_tx_args);
+    let deploy_contract_tx =
+        InvokeTransaction::create(deploy_contract_tx, &CHAIN_ID_FOR_TESTS).unwrap();
+    test_manager.add_invoke_tx(deploy_contract_tx);
+    // Invoke the `split_felt_wrapper` function of the deployed contract.
+    let args = invoke_tx_args! {
+        sender_address: *FUNDED_ACCOUNT_ADDRESS,
+        nonce: nonce_manager.next(*FUNDED_ACCOUNT_ADDRESS),
+        calldata: create_calldata(
+            expected_contract_address,
+            "split_felt_wrapper",
+            &[Felt::from(12345678901234567890u128)],
+        ),
+        resource_bounds: *NON_TRIVIAL_RESOURCE_BOUNDS,
+    };
+    let invoke_tx = invoke_tx(args);
+    let invoke_tx = InvokeTransaction::create(invoke_tx, &CHAIN_ID_FOR_TESTS).unwrap();
+    test_manager.add_invoke_tx(invoke_tx);
+
+    let initial_block_number = CURRENT_BLOCK_NUMBER + 1;
+    let _test_output =
+        test_manager.execute_test_with_default_block_contexts(initial_block_number).await;
 }


### PR DESCRIPTION
This branch is based on https://github.com/starkware-libs/sequencer/pull/8983, but uses https://github.com/lambdaclass/cairo-vm/pull/2191 to fix the test. If you want to run it locally, you have to change the dependencies to a local path with the VM modifications.

Before:
```
running 1 test
test tests::declare_deploy_invoke_cairo0_scenario ... FAILED

failures:

---- tests::declare_deploy_invoke_cairo0_scenario stdout ----

thread 'tests::declare_deploy_invoke_cairo0_scenario' panicked at crates/starknet_os_flow_tests/src/test_manager.rs:436:60:
called `Result::unwrap()` on an `Err` value: VmException(VmException { pc: Relocatable { segment_index: 77, offset: 183 }, inst_location: None, inner_exc: Hint((0, MissingConstant("MAX_HIGH"))), error_attr_value: None, traceback: Some("Cairo traceback (most recent call last):\n/Users/julian/projects/sequencer/crates/apollo_starknet_os_program/src/cairo/starkware/starknet/core/os/os.cairo:128:9: (pc=0:14492)\n        execute_blocks(\n        ^*************^\n/Users/julian/projects/sequencer/crates/apollo_starknet_os_program/src/cairo/starkware/starknet/core/os/os.cairo:309:9: (pc=0:14630)\n        execute_transactions(block_context=block_context);\n        ^***********************************************^\n/Users/julian/projects/sequencer/crates/apollo_starknet_os_program/src/cairo/starkware/starknet/core/os/execution/execute_transactions.cairo:168:5: (pc=0:13241)\n    execute_transactions_inner{\n    ^*************************^\n/Users/julian/projects/sequencer/crates/apollo_starknet_os_program/src/cairo/starkware/starknet/core/os/execution/execute_transactions.cairo:281:12: (pc=0:13353)\n    return execute_transactions_inner(block_context=block_context, n_txs=n_txs - 1);\n           ^**********************************************************************^\n/Users/julian/projects/sequencer/crates/apollo_starknet_os_program/src/cairo/starkware/starknet/core/os/execution/execute_transactions.cairo:262:16: (pc=0:13301)\n        return execute_transactions_inner(block_context=block_context, n_txs=n_txs - 1);\n               ^**********************************************************************^\n/Users/julian/projects/sequencer/crates/apollo_starknet_os_program/src/cairo/starkware/starknet/core/os/execution/execute_transactions.cairo:260:9: (pc=0:13296)\n        execute_invoke_function_transaction(block_context=block_context);\n        ^**************************************************************^\n/Users/julian/projects/sequencer/crates/apollo_starknet_os_program/src/cairo/starkware/starknet/core/os/execution/execute_transactions.cairo:533:13: (pc=0:13639)\n            non_reverting_select_execute_entry_point_func(\n            ^********************************************^\n/Users/julian/projects/sequencer/crates/apollo_starknet_os_program/src/cairo/starkware/starknet/core/os/execution/deprecated_execute_entry_point.cairo:290:63: (pc=0:7160)\n    let (is_reverted, retdata_size, retdata, is_deprecated) = select_execute_entry_point_func{\n                                                              ^******************************^\n/Users/julian/projects/sequencer/crates/apollo_starknet_os_program/src/cairo/starkware/starknet/core/os/execution/deprecated_execute_entry_point.cairo:264:48: (pc=0:7128)\n    let (is_reverted, retdata_size, retdata) = execute_entry_point{\n                                               ^******************^\n/Users/julian/projects/sequencer/crates/apollo_starknet_os_program/src/cairo/starkware/starknet/core/os/execution/execute_entry_point.cairo:325:9: (pc=0:6817)\n        call_execute_syscalls(\n        ^********************^\n/Users/julian/projects/sequencer/crates/apollo_starknet_os_program/src/cairo/starkware/starknet/core/os/execution/execute_syscalls.cairo:261:16: (pc=0:10196)\n        return execute_syscalls(\n               ^***************^\n/Users/julian/projects/sequencer/crates/apollo_starknet_os_program/src/cairo/starkware/starknet/core/os/execution/execute_syscalls.cairo:269:9: (pc=0:10212)\n        execute_call_contract(\n        ^********************^\n/Users/julian/projects/sequencer/crates/apollo_starknet_os_program/src/cairo/starkware/starknet/core/os/execution/execute_syscalls.cairo:566:5: (pc=0:10741)\n    contract_call_helper(\n    ^*******************^\n/Users/julian/projects/sequencer/crates/apollo_starknet_os_program/src/cairo/starkware/starknet/core/os/execution/execute_syscalls.cairo:756:68: (pc=0:10990)\n        let (is_reverted, retdata_size, retdata, _is_deprecated) = select_execute_entry_point_func(\n                                                                   ^******************************^\n/Users/julian/projects/sequencer/crates/apollo_starknet_os_program/src/cairo/starkware/starknet/core/os/execution/deprecated_execute_entry_point.cairo:236:59: (pc=0:7096)\n        let (is_reverted, retdata_size, retdata: felt*) = deprecated_execute_entry_point(\n                                                          ^*****************************^\n/Users/julian/projects/sequencer/crates/apollo_starknet_os_program/src/cairo/starkware/starknet/core/os/execution/deprecated_execute_entry_point.cairo:175:5: (pc=0:7043)\n    call abs contract_entry_point;\n    ^***************************^\nUnknown location (pc=77:578)\nUnknown location (pc=77:569)\n") })
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace


failures:
    tests::declare_deploy_invoke_cairo0_scenario

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 11 filtered out; finished in 5.56s
```

After:
```
running 1 test
test tests::declare_deploy_invoke_cairo0_scenario ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 11 filtered out; finished in 5.98s
```