### PR TITLE
Update Native dependency to (potential) 0.9.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4398,7 +4398,7 @@ dependencies = [
 [[package]]
 name = "cairo-native"
 version = "0.9.0-rc.0"
-source = "git+https://github.com/lambdaclass/cairo_native.git?rev=3299da5446b74b3d4e4682de7df08629ee6e0429#3299da5446b74b3d4e4682de7df08629ee6e0429"
+source = "git+https://github.com/lambdaclass/cairo_native.git?rev=9e042d19409c822291bf351beaddd00a69d5f2b1#9e042d19409c822291bf351beaddd00a69d5f2b1"
 dependencies = [
  "aquamarine",
  "ark-ec 0.5.0",
@@ -4419,6 +4419,7 @@ dependencies = [
  "educe 0.5.11",
  "itertools 0.14.0",
  "keccak",
+ "lambdaworks-math",
  "lazy_static",
  "libc",
  "libloading",
@@ -7991,6 +7992,7 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "rand 0.8.5",
+ "rayon",
  "serde",
  "serde_json",
 ]
@@ -11830,7 +11832,7 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 [[package]]
 name = "sierra-emu"
 version = "0.9.0-rc.0"
-source = "git+https://github.com/lambdaclass/cairo_native.git?rev=3299da5446b74b3d4e4682de7df08629ee6e0429#3299da5446b74b3d4e4682de7df08629ee6e0429"
+source = "git+https://github.com/lambdaclass/cairo_native.git?rev=9e042d19409c822291bf351beaddd00a69d5f2b1#9e042d19409c822291bf351beaddd00a69d5f2b1"
 dependencies = [
  "cairo-lang-compiler",
  "cairo-lang-filesystem",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,8 +231,8 @@ cairo-lang-sierra = "2.15.0"
 cairo-lang-sierra-to-casm = "2.15.0"
 cairo-lang-starknet-classes = "2.15.0"
 cairo-lang-utils = "2.15.0"
-cairo-native = { git = "https://github.com/lambdaclass/cairo_native.git", rev = "3299da5446b74b3d4e4682de7df08629ee6e0429" }
-sierra-emu = { git = "https://github.com/lambdaclass/cairo_native.git", rev = "3299da5446b74b3d4e4682de7df08629ee6e0429" }
+cairo-native = { git = "https://github.com/lambdaclass/cairo_native.git", rev = "9e042d19409c822291bf351beaddd00a69d5f2b1" }
+sierra-emu = { git = "https://github.com/lambdaclass/cairo_native.git", rev = "9e042d19409c822291bf351beaddd00a69d5f2b1" }
 cairo-vm = "3.0.0"
 camelpaste = "0.1.0"
 chrono = "0.4.26"


### PR DESCRIPTION
Bump Native to https://github.com/lambdaclass/cairo_native/commit/9e042d19409c822291bf351beaddd00a69d5f2b1